### PR TITLE
Fix furniture yaml parsing

### DIFF
--- a/src/PCH.h
+++ b/src/PCH.h
@@ -190,6 +190,20 @@ struct std::formatter<RE::BSFixedString> : std::formatter<const char*>
 	}
 };
 
+template<>
+struct fmt::formatter<YAML::Mark> : fmt::formatter<std::string>
+{
+	constexpr auto parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
+
+	template <typename FormatContext>
+    auto format(YAML::Mark mark, FormatContext &ctx) const -> decltype(ctx.out())
+	{
+		return fmt::format_to(ctx.out(), "[Ln {}, Col {}]", mark.line + 1, mark.column + 1);
+	}
+};
+
 #define DLLEXPORT __declspec(dllexport)
 
 #include "Plugin.h"

--- a/src/Registry/Define/Furniture.cpp
+++ b/src/Registry/Define/Furniture.cpp
@@ -48,25 +48,25 @@ namespace Registry
 		const auto parse_node = [&](const YAML::Node& it) {
 			const auto typenode = it["Type"];
 			if (!typenode.IsDefined()) {
-				logger::error("Missing 'Type' for node");
+				logger::error("Missing 'Type' for node {}", a_node.Mark());
 				return;
 			}
 			const auto typestr = typenode.as<std::string>();
 			const auto where = FurniTable.find(typestr);
 			if (where == FurniTable.end()) {
-				logger::error("Unrecognized Furniture: '{}'", typestr);
+				logger::error("Unrecognized Furniture: '{}' {}", typestr, typenode.Mark());
 				return;
 			}
 			const auto offsetnode = it["Offset"];
 			if (!offsetnode.IsDefined() || !offsetnode.IsSequence()) {
-				logger::error("Missing 'Offset' node for type '{}'", typestr);
+				logger::error("Missing 'Offset' node for type '{}' {}", typestr, typenode.Mark());
 				return;
 			}
 			std::vector<Coordinate> offsets{};
 			const auto push = [&](const YAML::Node& node) {
 				const auto vec = node.as<std::vector<float>>();
 				if (vec.size() != 4) {
-					logger::error("Invalid offset size. Expected 4 but got {}", vec.size());
+					logger::error("Invalid offset size. Expected 4 but got {} {}", vec.size(), node.Mark());
 					return;
 				}
 				Coordinate coords(vec);
@@ -81,7 +81,7 @@ namespace Registry
 				push(offsetnode);
 			}
 			if (offsets.empty()) {
-				logger::error("Type '{}' is defined but has no valid offsets", typestr);
+				logger::error("Type '{}' is defined but has no valid offsets {}", typestr, typenode.Mark());
 				return;
 			}
 			_data.emplace_back(where->second, std::move(offsets));


### PR DESCRIPTION
Fixes a few issues that were preventing furniture yamls from being loaded

- Handles the case where a model is defined with a single map instead of a sequence
- Read from "Type" node instead of trying to convert entire map to string
- Fix inverted `offsetnode.IsDefined()` check

Also added line and column numbers to the error logging, which was useful while debugging, as a separate commit so they're easy to exclude if unwanted.