### PR TITLE
fix av in Legacy_IsCompatibleSexCountCrt

### DIFF
--- a/src/Registry/Animation.cpp
+++ b/src/Registry/Animation.cpp
@@ -594,7 +594,7 @@ namespace Registry
 				return true;
 			}
 
-			std::vector<int> count;
+			int count[3];
 			for (auto&& position : positions) {
 				if (position.race == Registry::RaceKey::Human)
 					continue;


### PR DESCRIPTION
Crash log from discord
```
SkyrimSE v1.6.1170
trainwreck v1.4.0

Unhandled exception "EXCEPTION_ACCESS_VIOLATION" at 0x7FFE4657FA64 SexLabUtil.dll+006FA64 `Registry::Scene::Legacy_IsCompatibleSexCountCrt'::`2'::<lambda_1>::operator()

SYSTEM SPECS:
    OS: Microsoft Windows 11 Education 23H2 22631.4890
    CPU: AuthenticAMD AMD Ryzen 7 7800X3D 8-Core Processor           
    GPU #1: NVIDIA GeForce RTX 3080
    GPU #2: AMD Radeon(TM) Graphics
    GPU #3: Microsoft Basic Render Driver
    RAM: 34.05 GiB/63.12 GiB
    PAGE FILE: 40.89 GiB/72.12 GiB

PROBABLE CALL STACK:
    [0 ] 0x7FFE4657FA64 SexLabUtil.dll+006FA64 `Registry::Scene::Legacy_IsCompatibleSexCountCrt'::`2'::<lambda_1>::operator()
        [C:\dev\skse64\SexLabpp\src\Registry\Animation.cpp:601]
        inc dword ptr [r9]
```