### PR TITLE
fix tracking hooks load from saved game

### DIFF
--- a/src/PCH.h
+++ b/src/PCH.h
@@ -93,10 +93,11 @@ namespace stl
 		if (!a_intfc->ReadRecordData(size)) {
 			return false;
 		}
-		a_str.reserve(size);
+		a_str.resize(size);
 		if (!a_intfc->ReadRecordData(a_str.data(), static_cast<std::uint32_t>(size))) {
 			return false;
 		}
+		a_str.erase(std::find(a_str.cbegin(), a_str.cend(), '\0'), a_str.cend());
 		return true;
 	}
 

--- a/src/Papyrus/sslLibrary/Serialize.h
+++ b/src/Papyrus/sslLibrary/Serialize.h
@@ -92,6 +92,9 @@ namespace Papyrus
 						list.push_back(next);
 					}
 					toload.insert({ newid, list });
+
+					a_intfc->ReadRecordData(id);
+					assert(id == (std::numeric_limits<uint32_t>::max)());
 				}
 			};
 


### PR DESCRIPTION
std::string::reserve() doesn't set size, so all future access just sees an empty string (even though data was loaded into the reserved memory). 