### PR TITLE
Furniture fix

### DIFF
--- a/src/Registry/Define/Animation.cpp
+++ b/src/Registry/Define/Animation.cpp
@@ -142,7 +142,7 @@ namespace Registry
 			graph.insert(std::make_pair(vertex, edges));
 		}
 		// --- Misc
-		a_stream.read(reinterpret_cast<char*>(&furnitureTypes), 4);
+		Decode::Read(a_stream, *reinterpret_cast<uint32_t*>(&furnitureTypes));
 		a_stream.read(reinterpret_cast<char*>(&allowBed), 1);
 		furnitureOffset = Coordinate(a_stream);
 		a_stream.read(reinterpret_cast<char*>(&isPrivate), 1);

--- a/src/Registry/Define/Furniture.cpp
+++ b/src/Registry/Define/Furniture.cpp
@@ -128,6 +128,7 @@ namespace Registry
 					return;
 				}
 				Coordinate coords{ vec };
+				coords.rotation = glm::radians(coords.rotation);
 				data.emplace_back(furniture, coords);
 			};
 			if (offsetnode[0].IsSequence()) {

--- a/src/Registry/Define/Transform.cpp
+++ b/src/Registry/Define/Transform.cpp
@@ -26,8 +26,8 @@ namespace Registry
 
 	void Coordinate::Apply(Coordinate& a_coordinate) const
 	{
-		const float cosAngle = std::cos(a_coordinate.rotation);
-		const float sinAngle = std::sin(a_coordinate.rotation);
+		const float cosAngle = std::cos(-a_coordinate.rotation);
+		const float sinAngle = std::sin(-a_coordinate.rotation);
 		const glm::vec3 transform{
 			location.x * cosAngle - location.y * sinAngle,
 			location.x * sinAngle + location.y * cosAngle,


### PR DESCRIPTION
Fixes incorrect animation selection due to endian mismatch reading furniture types, and misaligned furniture offsets due to radian/degree mismatch and incorrect rotation orientation for coordinate transform.