### PR TITLE
fix thread safety for raycasting

### DIFF
--- a/src/Registry/Util/RayCast/Offsets.h
+++ b/src/Registry/Util/RayCast/Offsets.h
@@ -2,6 +2,9 @@
 
 namespace Offsets
 {
+
+    static constexpr auto NotOnGameThread=REL::VariantID(38079, 39033, 0x6488a0);
+
     // SE: 2F4C910
     // AE: ???
     static constexpr auto WorldToCamMatrix = RELOCATION_ID(519579, 406126);

--- a/src/Registry/Util/RayCast/RayCast.cpp
+++ b/src/Registry/Util/RayCast/RayCast.cpp
@@ -68,6 +68,10 @@ Raycast::RayResult Raycast::hkpCastRay(const glm::vec4& start, const glm::vec4& 
 
 Raycast::RayResult Raycast::hkpCastRay(const glm::vec4& start, const glm::vec4& end, const std::vector<RE::NiAVObject*>& a_filter) noexcept
 {
+    if (((bool (*)(void))Offsets::NotOnGameThread.address())()) {
+        logger::error("hkpCastRay was called on wrong thread, this should never happen and can cause random CTD/freezes");
+    }
+    
     const auto hkpScale = RE::bhkWorld::GetWorldScale();
     const auto dif = end - start;
 

--- a/src/Thread/Thread.cpp
+++ b/src/Thread/Thread.cpp
@@ -4,7 +4,8 @@
 #include "Registry/Util/Scale.h"
 #include "Thread/Interface/SceneMenu.h"
 #include "Util/Script.h"
-
+#include "Registry/Util/RayCast/Offsets.h"
+#include <future>
 namespace Thread
 {
     bool Instance::CreateInstance(RE::TESQuest* a_linkedQst, const std::vector<RE::Actor*> a_submissives, const SceneMapping& a_scenes, FurniturePreference a_furniturePreference)
@@ -215,12 +216,17 @@ namespace Thread
             }
             center.SetReference(a_ref, {});
         } else {
-            const auto inBounds = details->GetClosestCoordinatesInBound(a_ref, center.offset.type.value, center.GetRef());
-            if (inBounds.empty()) {
-                logger::warn("Reference {:X} is not compatible with any scene.", a_ref->GetFormID());
+            if (((bool (*)(void))Offsets::NotOnGameThread.address())()) {
+                logger::error("ReplaceCenterRef called on non-game thread, this should never happen, skipping execution!");
                 return false;
+            } else {
+                const auto inBounds = details->GetClosestCoordinatesInBound(a_ref, center.offset.type.value, center.GetRef());
+                if (inBounds.empty()) {
+                    logger::warn("Reference {:X} is not compatible with any scene.", a_ref->GetFormID());
+                    return false;
+                }
+                center.SetReference(a_ref, inBounds.front());
             }
-            center.SetReference(a_ref, inBounds.front());
         }
         baseCoordinates = center.offset.offset.ApplyReturn(center.GetRef());
         activeScene->furnitureOffset.Apply(baseCoordinates);

--- a/src/Thread/ThreadCtor.cpp
+++ b/src/Thread/ThreadCtor.cpp
@@ -126,7 +126,7 @@ namespace Thread
         std::promise<bool> promise;
         auto future = promise.get_future();
         const auto selectionMethod = GetSelectionMethod(furniturePreference);
-        SKSE::GetTaskInterface()->AddUITask([&]() mutable {
+        SKSE::GetTaskInterface()->AddTask([&]() mutable {
             try {
                 if (center.GetRef() && InitializeFixedCenter(centerAct, prioScenes, sceneTypes)) {
                     logger::info("Using fixed center {:X} with offset {}.", center.GetRef()->GetFormID(), center.offset.type.ToString());


### PR DESCRIPTION
Fixes #21
and adds logging in case something calls hkpCastRay from the wrong thread.