### PR TITLE
refactor: replace nlohmann/json with glaze

### DIFF
--- a/src/PCH.h
+++ b/src/PCH.h
@@ -7,9 +7,9 @@
 #pragma warning(pop)
 
 #include <atomic>
+#include <glaze/glaze.hpp>
 #include <glm/glm.hpp>
 #include <magic_enum.hpp>
-#include <nlohmann/json.hpp>
 #include <ranges>
 #include <unordered_map>
 #include <yaml-cpp/yaml.h>

--- a/src/Registry/Define/Expression.cpp
+++ b/src/Registry/Define/Expression.cpp
@@ -2,6 +2,27 @@
 
 namespace Registry
 {
+    namespace detail
+    {
+        struct LegacyExpressionStrings
+        {
+            std::optional<std::string> name;
+        };
+
+        struct LegacyExpression
+        {
+            std::optional<LegacyExpressionStrings> string;
+            std::optional<std::unordered_map<std::string, std::vector<float>>> floatList;
+            std::optional<std::unordered_map<std::string, int32_t>> integers;
+
+            struct glaze
+            {
+                using T = LegacyExpression;
+                static constexpr auto value = glz::object(&T::string, &T::floatList, "int", &T::integers);
+            };
+        };
+    }
+
     Expression::Expression(const YAML::Node& a_src) :
       id(a_src["id"].as<std::string>("Missing Name")),
       version(static_cast<uint8_t>(a_src["version"].as<uint32_t>(0))),
@@ -25,48 +46,53 @@ namespace Registry
         }
     }
 
-    Expression::Expression(const nlohmann::json& a_src) :
-      id([&]() {
-          if (const auto strings = a_src.find("string"); strings != a_src.end())
-              if (const auto name = strings->find("name"); name != strings->end())
-                  return name->get<std::string>();
-          throw std::runtime_error("Missing Name field");
-      }())
+    Expression Expression::FromLegacyFile(const fs::path& a_path)
     {
-        const auto floats = a_src.find("floatList");
-        if (floats == a_src.end())
+        detail::LegacyExpression source;
+        std::string buffer;
+        const auto filename = a_path.string();
+        constexpr glz::opts options{ .error_on_unknown_keys = false };
+        if (const auto error = glz::read_file_json<options>(source, filename, buffer); error) {
+            throw std::runtime_error(glz::format_error(error, buffer));
+        }
+        if (!source.string || !source.string->name || source.string->name->empty())
+            throw std::runtime_error("Missing Name field");
+        if (!source.floatList)
             throw std::runtime_error("Missing 'floatList' field");
-        auto fill = [&](RE::SEXES::SEX sex, std::string prefix) mutable {
+
+        Expression expression{ RE::BSFixedString{ *source.string->name } };
+        auto fill = [&](RE::SEXES::SEX sex, std::string prefix) {
             constexpr auto MAX_VALUE_FIELDS = 5;
             for (size_t i = 1; i <= MAX_VALUE_FIELDS; i++) {
                 auto fieldname = prefix + std::to_string(i);
-                auto field = floats->find(fieldname);
-                if (field == floats->end() || !field->is_array())
+                auto field = source.floatList->find(fieldname);
+                if (field == source.floatList->end())
                     break;
-                auto values = field->get<std::vector<float>>();
+                const auto& values = field->second;
                 if (values.size() != ValueType::Total) {
-                    const auto err = std::format("Invalid value field, expected {}/32 values found in field {}", values.size(), fieldname);
-                    throw std::runtime_error(err.c_str());
+                    const auto err = std::format("Invalid value field: expected 32 values, found {} in field {}", values.size(), fieldname);
+                    throw std::runtime_error(err);
                 }
-                auto& it = data[sex].emplace_back();
+                auto& it = expression.data[sex].emplace_back();
                 std::copy_n(values.begin(), it.size(), it.begin());
             }
         };
         fill(RE::SEXES::kMale, "male");
         fill(RE::SEXES::kFemale, "female");
-        if (data[RE::SEXES::kMale].empty() && data[RE::SEXES::kFemale].empty()) {
+        if (expression.data[RE::SEXES::kMale].empty() && expression.data[RE::SEXES::kFemale].empty()) {
             throw std::runtime_error("Data fields have no values");
         }
-        if (const auto ints = a_src.find("int"); ints != a_src.end()) {
+        if (source.integers) {
             const auto get = [&](const char* fieldname) -> bool {
-                auto field = ints->find(fieldname);
-                return field != ints->end() && field->get<int>() == 1;
+                auto field = source.integers->find(fieldname);
+                return field != source.integers->end() && field->second == 1;
             };
-            enabled = get("enabled");
+            expression.enabled = get("enabled");
             for (auto&& tag : { "aggressor", "normal", "victim " })
                 if (get(tag))
-                    tags.AddTag(tag);
+                    expression.tags.AddTag(tag);
         }
+        return expression;
     }
 
     Expression::Expression(DefaultExpression a_default) :

--- a/src/Registry/Define/Expression.h
+++ b/src/Registry/Define/Expression.h
@@ -43,8 +43,9 @@ namespace Registry
           id(a_id) { assert(!a_id.empty()); };
         Expression(DefaultExpression a_default);
         Expression(const YAML::Node& a_src);
-        Expression(const nlohmann::json& a_src);
         ~Expression() = default;
+
+        static Expression FromLegacyFile(const fs::path& a_path);
 
         bool IsEnabled() const { return enabled; }
         RE::BSFixedString GetId() const { return id; }

--- a/src/Registry/Library_SaveLoad.cpp
+++ b/src/Registry/Library_SaveLoad.cpp
@@ -212,8 +212,7 @@ namespace Registry
             if (!filename.starts_with("expression"))
                 continue;
             try {
-                const auto jsonfile = nlohmann::json::parse(std::ifstream(file.path().string()));
-                auto profile = Expression{ jsonfile };
+                auto profile = Expression::FromLegacyFile(file.path());
                 auto succ = expressions.emplace(profile.GetId(), std::move(profile));
                 if (succ.second) {
                     succ.first->second.Save(EXPRESSION_PATH, true);

--- a/xmake-requires.lock
+++ b/xmake-requires.lock
@@ -14,7 +14,7 @@
         ["directxmath 2024.02#f56260b5"] = {
             repo = {
                 branch = "master",
-                commit = "3a3468812c7cea1482d114361c40034c3db07274",
+                commit = "33a3d2592b35c2e02b01b0824a9f017a787ddec1",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "2024.02"
@@ -22,7 +22,7 @@
         ["directxtk 24.2.0#f56260b5"] = {
             repo = {
                 branch = "master",
-                commit = "3a3468812c7cea1482d114361c40034c3db07274",
+                commit = "33a3d2592b35c2e02b01b0824a9f017a787ddec1",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "24.2.0"
@@ -31,9 +31,17 @@
             repo = {
                 branch = "master",
                 commit = "8917c2f7818847fead2be9b3b6f77d90d97323f3",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
+                url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "5.0.1"
+        },
+        ["glaze#f56260b5"] = {
+            repo = {
+                branch = "master",
+                commit = "3a3468812c7cea1482d114361c40034c3db07274",
+                url = "https://github.com/xmake-io/xmake-repo.git"
+            },
+            version = "v7.0.2"
         },
         ["glm#f56260b5"] = {
             repo = {
@@ -59,18 +67,10 @@
             },
             version = "v1.13.1"
         },
-        ["nlohmann_json#f56260b5"] = {
-            repo = {
-                branch = "master",
-                commit = "3a3468812c7cea1482d114361c40034c3db07274",
-                url = "https://github.com/xmake-io/xmake-repo.git"
-            },
-            version = "v3.12.0"
-        },
         ["rapidcsv v8.92#f56260b5"] = {
             repo = {
                 branch = "master",
-                commit = "3a3468812c7cea1482d114361c40034c3db07274",
+                commit = "33a3d2592b35c2e02b01b0824a9f017a787ddec1",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "v8.92"
@@ -86,7 +86,7 @@
         ["spdlog v1.16.0#09c8c173"] = {
             repo = {
                 branch = "master",
-                commit = "3a3468812c7cea1482d114361c40034c3db07274",
+                commit = "33a3d2592b35c2e02b01b0824a9f017a787ddec1",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "v1.16.0"

--- a/xmake.lua
+++ b/xmake.lua
@@ -92,7 +92,7 @@ option_end()
 
 -- Dependencies & Includes
 -- https://github.com/xmake-io/xmake-repo/tree/dev
-add_requires("yaml-cpp", "magic_enum", "nlohmann_json", "simpleini", "glm", "eigen")
+add_requires("yaml-cpp", "magic_enum", "glaze", "simpleini", "glm", "eigen")
 
 -- policies
 set_policy("package.requires_lock", true)
@@ -151,7 +151,7 @@ add_rules("common")
 target(PROJECT_NAME)
     set_enabled(get_config("build_dll"))
     -- Dependencies
-    add_packages("yaml-cpp", "magic_enum", "nlohmann_json", "simpleini", "glm", "eigen")
+    add_packages("yaml-cpp", "magic_enum", "glaze", "simpleini", "glm", "eigen")
 
     -- CommonLibSSE
     add_deps("commonlibsse-ng")


### PR DESCRIPTION
Switch to glaze instead of nlohmann.

**Reasons:**

- **Compile time reflection for MSVC**. Literally a godsend for low boilerplate serialization/deserialization. This will allow us to make stuff such as the Theme.h elements configurable with just a few lines of code. Yes my `FromLegacyFile` contains boilerplate, but that's because it's having to map legacy schema junk, validate data, and so on. In normal use, that could have been a few lines of code. 
- Supports all sorts of formats such as YAML
- Extremely fast
- Modern API with greater readability 

Idea after this is to make the UI theme very configurable without having to introduce all sorts of macros and disgusting boilerplate. 

Also just a note, I changed `Expression` to `FromLegacyFile` because it was confusing. Difficult to decide between what's legacy and what's modern without explicit naming conventions. 

https://github.com/stephenberry/glaze