### PR TITLE
Glaze imgui config

### DIFF
--- a/src/PCH.h
+++ b/src/PCH.h
@@ -7,9 +7,9 @@
 #pragma warning(pop)
 
 #include <atomic>
+#include <glaze/glaze.hpp>
 #include <glm/glm.hpp>
 #include <magic_enum.hpp>
-#include <nlohmann/json.hpp>
 #include <ranges>
 #include <unordered_map>
 #include <yaml-cpp/yaml.h>

--- a/src/Registry/Define/Expression.cpp
+++ b/src/Registry/Define/Expression.cpp
@@ -2,6 +2,27 @@
 
 namespace Registry
 {
+    namespace detail
+    {
+        struct LegacyExpressionStrings
+        {
+            std::optional<std::string> name;
+        };
+
+        struct LegacyExpression
+        {
+            std::optional<LegacyExpressionStrings> string;
+            std::optional<std::unordered_map<std::string, std::vector<float>>> floatList;
+            std::optional<std::unordered_map<std::string, int32_t>> integers;
+
+            struct glaze
+            {
+                using T = LegacyExpression;
+                static constexpr auto value = glz::object(&T::string, &T::floatList, "int", &T::integers);
+            };
+        };
+    }
+
     Expression::Expression(const YAML::Node& a_src) :
       id(a_src["id"].as<std::string>("Missing Name")),
       version(static_cast<uint8_t>(a_src["version"].as<uint32_t>(0))),
@@ -25,48 +46,53 @@ namespace Registry
         }
     }
 
-    Expression::Expression(const nlohmann::json& a_src) :
-      id([&]() {
-          if (const auto strings = a_src.find("string"); strings != a_src.end())
-              if (const auto name = strings->find("name"); name != strings->end())
-                  return name->get<std::string>();
-          throw std::runtime_error("Missing Name field");
-      }())
+    Expression Expression::FromLegacyFile(const fs::path& a_path)
     {
-        const auto floats = a_src.find("floatList");
-        if (floats == a_src.end())
+        detail::LegacyExpression source;
+        std::string buffer;
+        const auto filename = a_path.string();
+        constexpr glz::opts options{ .error_on_unknown_keys = false };
+        if (const auto error = glz::read_file_json<options>(source, filename, buffer); error) {
+            throw std::runtime_error(glz::format_error(error, buffer));
+        }
+        if (!source.string || !source.string->name || source.string->name->empty())
+            throw std::runtime_error("Missing Name field");
+        if (!source.floatList)
             throw std::runtime_error("Missing 'floatList' field");
-        auto fill = [&](RE::SEXES::SEX sex, std::string prefix) mutable {
+
+        Expression expression{ RE::BSFixedString{ *source.string->name } };
+        auto fill = [&](RE::SEXES::SEX sex, std::string prefix) {
             constexpr auto MAX_VALUE_FIELDS = 5;
             for (size_t i = 1; i <= MAX_VALUE_FIELDS; i++) {
                 auto fieldname = prefix + std::to_string(i);
-                auto field = floats->find(fieldname);
-                if (field == floats->end() || !field->is_array())
+                auto field = source.floatList->find(fieldname);
+                if (field == source.floatList->end())
                     break;
-                auto values = field->get<std::vector<float>>();
+                const auto& values = field->second;
                 if (values.size() != ValueType::Total) {
-                    const auto err = std::format("Invalid value field, expected {}/32 values found in field {}", values.size(), fieldname);
-                    throw std::runtime_error(err.c_str());
+                    const auto err = std::format("Invalid value field: expected 32 values, found {} in field {}", values.size(), fieldname);
+                    throw std::runtime_error(err);
                 }
-                auto& it = data[sex].emplace_back();
+                auto& it = expression.data[sex].emplace_back();
                 std::copy_n(values.begin(), it.size(), it.begin());
             }
         };
         fill(RE::SEXES::kMale, "male");
         fill(RE::SEXES::kFemale, "female");
-        if (data[RE::SEXES::kMale].empty() && data[RE::SEXES::kFemale].empty()) {
+        if (expression.data[RE::SEXES::kMale].empty() && expression.data[RE::SEXES::kFemale].empty()) {
             throw std::runtime_error("Data fields have no values");
         }
-        if (const auto ints = a_src.find("int"); ints != a_src.end()) {
+        if (source.integers) {
             const auto get = [&](const char* fieldname) -> bool {
-                auto field = ints->find(fieldname);
-                return field != ints->end() && field->get<int>() == 1;
+                auto field = source.integers->find(fieldname);
+                return field != source.integers->end() && field->second == 1;
             };
-            enabled = get("enabled");
+            expression.enabled = get("enabled");
             for (auto&& tag : { "aggressor", "normal", "victim " })
                 if (get(tag))
-                    tags.AddTag(tag);
+                    expression.tags.AddTag(tag);
         }
+        return expression;
     }
 
     Expression::Expression(DefaultExpression a_default) :

--- a/src/Registry/Define/Expression.h
+++ b/src/Registry/Define/Expression.h
@@ -43,8 +43,9 @@ namespace Registry
           id(a_id) { assert(!a_id.empty()); };
         Expression(DefaultExpression a_default);
         Expression(const YAML::Node& a_src);
-        Expression(const nlohmann::json& a_src);
         ~Expression() = default;
+
+        static Expression FromLegacyFile(const fs::path& a_path);
 
         bool IsEnabled() const { return enabled; }
         RE::BSFixedString GetId() const { return id; }

--- a/src/Registry/Library_SaveLoad.cpp
+++ b/src/Registry/Library_SaveLoad.cpp
@@ -212,8 +212,7 @@ namespace Registry
             if (!filename.starts_with("expression"))
                 continue;
             try {
-                const auto jsonfile = nlohmann::json::parse(std::ifstream(file.path().string()));
-                auto profile = Expression{ jsonfile };
+                auto profile = Expression::FromLegacyFile(file.path());
                 auto succ = expressions.emplace(profile.GetId(), std::move(profile));
                 if (succ.second) {
                     succ.first->second.Save(EXPRESSION_PATH, true);

--- a/src/Thread/Interface/Elements/AnimSpeedOverlay.cpp
+++ b/src/Thread/Interface/Elements/AnimSpeedOverlay.cpp
@@ -93,16 +93,16 @@ namespace Thread::Interface
         SKSEMenuFramework::PushFont(UI::Theme::Icon::solidFont);
         DrawTextShadowed(dl,
             ImGuiMCP::ImVec2{ rowScreenPos.x + (btnW - leftIconSize.x) * 0.5f, rowScreenPos.y + (rowH - leftIconSize.y) * 0.5f },
-            UI::Theme::Color::textSecondary, UI::Theme::Icon::anglesLeft);
+            UI::Theme::Color.textSecondary, UI::Theme::Icon::anglesLeft);
         DrawTextShadowed(dl,
             ImGuiMCP::ImVec2{ rowScreenPos.x + contentW - btnW + (btnW - rightIconSize.x) * 0.5f,
                 rowScreenPos.y + (rowH - rightIconSize.y) * 0.5f },
-            UI::Theme::Color::textSecondary, UI::Theme::Icon::anglesRight);
+            UI::Theme::Color.textSecondary, UI::Theme::Icon::anglesRight);
         FontAwesome::Pop();
         DrawTextShadowed(dl,
             ImGuiMCP::ImVec2{ rowScreenPos.x + (contentW - valSz.x) * 0.5f,
                 rowScreenPos.y + (rowH - valSz.y) * 0.5f },
-            UI::Theme::Color::textPrimary, buf);
+            UI::Theme::Color.textPrimary, buf);
         ImGuiMCP::SetCursorScreenPos(rowScreenPos);
         ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ contentW, rowH });
 
@@ -118,15 +118,15 @@ namespace Thread::Interface
 
             ImGuiMCP::ImDrawListManager::AddRectFilled(dl,
                 barPos, ImGuiMCP::ImVec2{ barPos.x + contentW, barPos.y + timerH },
-                UI::Theme::Animation::timerTrack, timerH * 0.5f, 0);
+                UI::Theme::Animation.timerTrack, timerH * 0.5f, 0);
             if (fillW > 0.0f) {
                 const float fx = barPos.x + contentW - fillW;
                 ImGuiMCP::ImDrawListManager::AddRectFilledMultiColor(dl,
                     ImGuiMCP::ImVec2{ fx, barPos.y }, ImGuiMCP::ImVec2{ barPos.x + contentW, barPos.y + timerH },
-                    UI::Theme::Animation::timerEdge,
-                    UI::Theme::Animation::timerCenter,
-                    UI::Theme::Animation::timerCenter,
-                    UI::Theme::Animation::timerEdge);
+                    UI::Theme::Animation.timerEdge,
+                    UI::Theme::Animation.timerCenter,
+                    UI::Theme::Animation.timerCenter,
+                    UI::Theme::Animation.timerEdge);
             }
             ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ contentW, timerH });
         }

--- a/src/Thread/Interface/Elements/ElementCtrlPanel.cpp
+++ b/src/Thread/Interface/Elements/ElementCtrlPanel.cpp
@@ -62,7 +62,7 @@ namespace Thread::Interface
             return;
         }
         SetWindowFontSize(scale.TextPx(UI::Theme::FontSize::body));
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color::textSecondary));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textSecondary));
 
         ImGuiMCP::SetNextItemWidth(-1.0f);
         ImGuiMCP::SliderFloat("##slpp_ecmScale", &_scaleAdjustment, 0.5f, 2.5f, "UI Scale %.2fx");
@@ -79,7 +79,7 @@ namespace Thread::Interface
         // Elements
         SetWindowFontSize(scale.TextPx(UI::Theme::FontSize::body));
         UI::PushCheckboxStyle(scale.Factor());
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color::textSecondary));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textSecondary));
 
         const float toggleRowH = scale.Px(24.0f);
         const float rowPadH = scale.Px(12.0f);
@@ -91,7 +91,7 @@ namespace Thread::Interface
 
             // Full row selectable button
             ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x + rowPadH, toggleRowMin.y });
-            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::ToVec4(UI::Theme::Color::transparent));
+            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::ToVec4(UI::Theme::Color.transparent));
             std::string rowId = std::string("##slpp_ecp_row_") + id;
             if (UI::SelectableButton(rowId.c_str(), false, 0, ImGuiMCP::ImVec2{ availW, toggleRowH })) {
                 state = !state;

--- a/src/Thread/Interface/Elements/ElementCtrlPanel.cpp
+++ b/src/Thread/Interface/Elements/ElementCtrlPanel.cpp
@@ -106,7 +106,6 @@ namespace Thread::Interface
             OnTextScaleChange(a_hud, _textScaleAdjustment);
 
         ImGuiMCP::PopStyleColor();
-        ImGuiMCP::Separator();
 
         // Elements
         SetWindowFontSize(scale.TextPx(UI::Theme::FontSize::body));
@@ -188,7 +187,6 @@ namespace Thread::Interface
         ImGuiMCP::PopStyleColor();
         UI::PopCheckboxStyle();
 
-        ImGuiMCP::Separator();
         const float actionGap = scale.Px(UI::Theme::Spacing::sm);
         const float actionWidth = (ImGuiMCP::GetContentRegionAvail().x - actionGap) * 0.5f;
         ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textSecondary));

--- a/src/Thread/Interface/Elements/ElementCtrlPanel.cpp
+++ b/src/Thread/Interface/Elements/ElementCtrlPanel.cpp
@@ -8,7 +8,6 @@ namespace Thread::Interface
 
     namespace
     {
-        constexpr auto COLOR_EDITOR_POPUP = "##slpp_ecpColorEditor";
         constexpr auto COLOR_EDIT_FLAGS =
             ImGuiMCP::ImGuiColorEditFlags_NoInputs |
             ImGuiMCP::ImGuiColorEditFlags_AlphaBar |
@@ -194,7 +193,7 @@ namespace Thread::Interface
         const float actionWidth = (ImGuiMCP::GetContentRegionAvail().x - actionGap) * 0.5f;
         ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textSecondary));
         if (UI::ActionButton("Adjust Colors", actionWidth))
-            ImGuiMCP::OpenPopup(COLOR_EDITOR_POPUP);
+            _showColorEditor = true;
         ImGuiMCP::SameLine(0.0f, actionGap);
         ImGuiMCP::BeginDisabled(!UI::Theme::IsLoaded());
         if (UI::ActionButton("Save", actionWidth))
@@ -202,29 +201,38 @@ namespace Thread::Interface
         ImGuiMCP::EndDisabled();
         ImGuiMCP::PopStyleColor();
 
-        const float popupWidth = std::min(scale.Px(200.0f), io->DisplaySize.x * 0.8f);
-        const float popupMinHeight = scale.Px(100.0f);
-        const float popupMaxHeight = std::max(popupMinHeight, io->DisplaySize.y * 0.75f);
-        const ImGuiMCP::ImVec2 elementPanelPos = ImGuiMCP::GetWindowPos();
-        const float elementPanelCenterY = elementPanelPos.y + ImGuiMCP::GetWindowHeight() * 0.5f;
+        ImGuiMCP::SetWindowFontScale(1.0f);
+        ImGuiMCP::End();
+    }
+
+    void ElementCtrlPanel::RenderColorEditor(SceneHUD& a_hud)
+    {
+        if (!_showColorEditor)
+            return;
+
+        auto& scale = a_hud.GetScale();
+        auto* io = ImGuiMCP::GetIO();
+        const float editorWidth = std::min(scale.Px(200.0f), io->DisplaySize.x * 0.8f);
+        const float editorMinHeight = scale.Px(100.0f);
+        const float editorMaxHeight = std::max(editorMinHeight, io->DisplaySize.y * 0.75f);
+        const float panelOffset = scale.Px(UI::Theme::Geometry::panelTabWidth + UI::Theme::Geometry::panelTabGap);
+        const float editorRight = io->DisplaySize.x - panelOffset - scale.Px(220.0f) - scale.Px(UI::Theme::Spacing::sm);
+
+        ImGuiMCP::SetNextWindowPos(ImGuiMCP::ImVec2{ editorRight, io->DisplaySize.y * 0.5f },
+            ImGuiMCP::ImGuiCond_FirstUseEver, ImGuiMCP::ImVec2{ 1.0f, 0.5f });
         ImGuiMCP::SetNextWindowSizeConstraints(
-            ImGuiMCP::ImVec2{ popupWidth, popupMinHeight }, ImGuiMCP::ImVec2{ popupWidth, popupMaxHeight });
-        ImGuiMCP::SetNextWindowPos(
-            ImGuiMCP::ImVec2{ elementPanelPos.x - scale.Px(UI::Theme::Spacing::sm), elementPanelCenterY },
-            ImGuiMCP::ImGuiCond_Always, ImGuiMCP::ImVec2{ 1.0f, 0.5f });
+            ImGuiMCP::ImVec2{ editorWidth, editorMinHeight }, ImGuiMCP::ImVec2{ editorWidth, editorMaxHeight });
 
-        if (ImGuiMCP::BeginPopup(COLOR_EDITOR_POPUP)) {
-
-            SetWindowFontSize(scale.TextPx(UI::Theme::FontSize::body));
-            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textPrimary), "Theme Colors");
-            ImGuiMCP::Separator();
-            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textSecondary));
-            DrawThemeColorFields(UI::Theme::data);
-            ImGuiMCP::PopStyleColor();
-            ImGuiMCP::SetWindowFontScale(1.0f);
-            ImGuiMCP::EndPopup();
+        constexpr auto kFlags = ImGuiMCP::ImGuiWindowFlags_NoCollapse | ImGuiMCP::ImGuiWindowFlags_AlwaysAutoResize;
+        if (!ImGuiMCP::Begin("Theme Colors##slpp_ColorEditor", &_showColorEditor, kFlags)) {
+            ImGuiMCP::End();
+            return;
         }
 
+        SetWindowFontSize(scale.TextPx(UI::Theme::FontSize::body));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textSecondary));
+        DrawThemeColorFields(UI::Theme::data);
+        ImGuiMCP::PopStyleColor();
         ImGuiMCP::SetWindowFontScale(1.0f);
         ImGuiMCP::End();
     }

--- a/src/Thread/Interface/Elements/ElementCtrlPanel.cpp
+++ b/src/Thread/Interface/Elements/ElementCtrlPanel.cpp
@@ -6,6 +6,39 @@ namespace Thread::Interface
 {
     using UI::SetWindowFontSize;
 
+    namespace
+    {
+        constexpr auto COLOR_EDITOR_POPUP = "##slpp_ecpColorEditor";
+        constexpr auto COLOR_EDIT_FLAGS =
+            ImGuiMCP::ImGuiColorEditFlags_NoInputs |
+            ImGuiMCP::ImGuiColorEditFlags_AlphaBar |
+            ImGuiMCP::ImGuiColorEditFlags_AlphaPreviewHalf;
+
+        template <class T>
+        void DrawThemeColorFields(T& a_values)
+        {
+            std::size_t index = 0;
+            glz::for_each_field(a_values, [&](auto& a_field) {
+                using Field = std::remove_cvref_t<decltype(a_field)>;
+
+                const auto fieldIndex = index++;
+                const auto fieldName = glz::reflect<T>::keys[fieldIndex];
+                ImGuiMCP::PushID(static_cast<int>(fieldIndex));
+
+                if constexpr (std::is_same_v<Field, ImGuiMCP::ImU32>) {
+                    auto color = UI::Theme::ToVec4(a_field);
+                    if (ImGuiMCP::ColorEdit4(fieldName.data(), &color.x, COLOR_EDIT_FLAGS))
+                        a_field = ImGuiMCP::ColorConvertFloat4ToU32(color);
+                } else if constexpr (glz::reflectable<Field>) {
+                    if (ImGuiMCP::CollapsingHeader(fieldName.data(), ImGuiMCP::ImGuiTreeNodeFlags_DefaultOpen))
+                        DrawThemeColorFields(a_field);
+                }
+
+                ImGuiMCP::PopID();
+            });
+        }
+    }
+
     void ElementCtrlPanel::Open(SceneHUD& a_hud)
     {
         if (auto* inst = a_hud.GetThreadInstance()) {
@@ -155,6 +188,43 @@ namespace Thread::Interface
         }
         ImGuiMCP::PopStyleColor();
         UI::PopCheckboxStyle();
+
+        ImGuiMCP::Separator();
+        const float actionGap = scale.Px(UI::Theme::Spacing::sm);
+        const float actionWidth = (ImGuiMCP::GetContentRegionAvail().x - actionGap) * 0.5f;
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textSecondary));
+        if (UI::ActionButton("Adjust Colors", actionWidth))
+            ImGuiMCP::OpenPopup(COLOR_EDITOR_POPUP);
+        ImGuiMCP::SameLine(0.0f, actionGap);
+        ImGuiMCP::BeginDisabled(!UI::Theme::IsLoaded());
+        if (UI::ActionButton("Save", actionWidth))
+            UI::Theme::Save();
+        ImGuiMCP::EndDisabled();
+        ImGuiMCP::PopStyleColor();
+
+        const float popupWidth = std::min(scale.Px(200.0f), io->DisplaySize.x * 0.8f);
+        const float popupMinHeight = scale.Px(100.0f);
+        const float popupMaxHeight = std::max(popupMinHeight, io->DisplaySize.y * 0.75f);
+        const ImGuiMCP::ImVec2 elementPanelPos = ImGuiMCP::GetWindowPos();
+        const float elementPanelCenterY = elementPanelPos.y + ImGuiMCP::GetWindowHeight() * 0.5f;
+        ImGuiMCP::SetNextWindowSizeConstraints(
+            ImGuiMCP::ImVec2{ popupWidth, popupMinHeight }, ImGuiMCP::ImVec2{ popupWidth, popupMaxHeight });
+        ImGuiMCP::SetNextWindowPos(
+            ImGuiMCP::ImVec2{ elementPanelPos.x - scale.Px(UI::Theme::Spacing::sm), elementPanelCenterY },
+            ImGuiMCP::ImGuiCond_Always, ImGuiMCP::ImVec2{ 1.0f, 0.5f });
+
+        if (ImGuiMCP::BeginPopup(COLOR_EDITOR_POPUP)) {
+
+            SetWindowFontSize(scale.TextPx(UI::Theme::FontSize::body));
+            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textPrimary), "Theme Colors");
+            ImGuiMCP::Separator();
+            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textSecondary));
+            DrawThemeColorFields(UI::Theme::data);
+            ImGuiMCP::PopStyleColor();
+            ImGuiMCP::SetWindowFontScale(1.0f);
+            ImGuiMCP::EndPopup();
+        }
+
         ImGuiMCP::SetWindowFontScale(1.0f);
         ImGuiMCP::End();
     }

--- a/src/Thread/Interface/Elements/ElementCtrlPanel.h
+++ b/src/Thread/Interface/Elements/ElementCtrlPanel.h
@@ -9,6 +9,7 @@ namespace Thread::Interface
         void Open(SceneHUD& a_hud);
         void Close();
         void Render(SceneHUD& a_hud);
+        void RenderColorEditor(SceneHUD& a_hud);
 
       private:
         void OnScaleChange(SceneHUD& a_hud, float a_value);
@@ -16,5 +17,6 @@ namespace Thread::Interface
 
         float _scaleAdjustment{ 1.5f };
         float _textScaleAdjustment{ 1.0f };
+        bool _showColorEditor{ false };
     };
 }

--- a/src/Thread/Interface/Elements/EnjBarsOverlay.cpp
+++ b/src/Thread/Interface/Elements/EnjBarsOverlay.cpp
@@ -119,17 +119,17 @@ namespace Thread::Interface
     void EnjBarsOverlay::FillGradient(float enj, ImGuiMCP::ImU32& lo, ImGuiMCP::ImU32& hi)
     {
         if (enj < 0.0f) {
-            lo = UI::Theme::Enjoyment::negativeHigh;
-            hi = UI::Theme::Enjoyment::negativeLow;
+            lo = UI::Theme::Enjoyment.negativeHigh;
+            hi = UI::Theme::Enjoyment.negativeLow;
             return;
         }
         if (enj > 100.0f) {
-            lo = UI::Theme::Enjoyment::overflowLow;
-            hi = UI::Theme::Enjoyment::overflowHigh;
+            lo = UI::Theme::Enjoyment.overflowLow;
+            hi = UI::Theme::Enjoyment.overflowHigh;
             return;
         }
-        lo = UI::Theme::Enjoyment::normalLow;
-        hi = UI::Theme::Enjoyment::normalHigh;
+        lo = UI::Theme::Enjoyment.normalLow;
+        hi = UI::Theme::Enjoyment.normalHigh;
     }
 
     float EnjBarsOverlay::GreenZoneHalfWidth(float a_enjoyment)
@@ -263,7 +263,7 @@ namespace Thread::Interface
                 ImGuiMCP::ImVec2{ nameMaxX, rowMaxY }, true);
             DrawTextShadowed(dl,
                 ImGuiMCP::ImVec2{ rowStart.x + lblPad, rowStart.y + lblPad },
-                b.isTarget ? UI::Theme::Color::textPrimary : UI::Theme::Color::textSecondary,
+                b.isTarget ? UI::Theme::Color.textPrimary : UI::Theme::Color.textSecondary,
                 b.name);
             ImGuiMCP::ImDrawListManager::PopClipRect(dl);
 
@@ -272,8 +272,8 @@ namespace Thread::Interface
             char valBuf[12];
             std::snprintf(valBuf, sizeof(valBuf), "%d",
                 static_cast<int>(std::round(b.enjoyment)));
-            const ImGuiMCP::ImU32 valCol = b.enjoyment > 100.0f ? UI::Theme::Enjoyment::overflowLow : b.enjoyment < 0.0f ? UI::Theme::Enjoyment::negativeHigh :
-                                                                                                                           UI::Theme::Color::textSecondary;
+            const ImGuiMCP::ImU32 valCol = b.enjoyment > 100.0f ? UI::Theme::Enjoyment.overflowLow : b.enjoyment < 0.0f ? UI::Theme::Enjoyment.negativeHigh :
+                                                                                                                          UI::Theme::Color.textSecondary;
             const float valX = rowStart.x + zoneW - ImGuiMCP::CalcTextSize(valBuf).x - lblPad;
             ImGuiMCP::ImDrawListManager::PushClipRect(dl,
                 ImGuiMCP::ImVec2{ valueMinX, rowStart.y }, ImGuiMCP::ImVec2{ rowStart.x + zoneW, rowMaxY }, true);
@@ -288,7 +288,7 @@ namespace Thread::Interface
                 ImGuiMCP::ImDrawListManager::PushClipRect(dl,
                     ImGuiMCP::ImVec2{ nameMaxX, rowStart.y }, ImGuiMCP::ImVec2{ valueMinX, rowMaxY }, true);
                 DrawTextShadowed(dl, ImGuiMCP::ImVec2{ intrX, rowStart.y + lblPad },
-                    UI::Theme::Color::textMuted, b.interactions);
+                    UI::Theme::Color.textMuted, b.interactions);
                 ImGuiMCP::ImDrawListManager::PopClipRect(dl);
             }
 
@@ -300,20 +300,20 @@ namespace Thread::Interface
             const ImGuiMCP::ImVec2 frameMax{ frameMin.x + zoneW, frameMin.y + frameH };
 
             // track
-            ImGuiMCP::ImDrawListManager::AddRectFilled(dl, frameMin, frameMax, UI::Theme::Enjoyment::frameSurface, 0.0f, 0);
-            ImGuiMCP::ImDrawListManager::AddRect(dl, frameMin, frameMax, UI::Theme::Enjoyment::frameBorder, 0.0f, 0, 1.0f);
+            ImGuiMCP::ImDrawListManager::AddRectFilled(dl, frameMin, frameMax, UI::Theme::Enjoyment.frameSurface, 0.0f, 0);
+            ImGuiMCP::ImDrawListManager::AddRect(dl, frameMin, frameMax, UI::Theme::Enjoyment.frameBorder, 0.0f, 0, 1.0f);
 
             // outer white rim
             ImGuiMCP::ImDrawListManager::AddRect(dl,
                 ImGuiMCP::ImVec2{ frameMin.x - 1, frameMin.y - 1 },
                 ImGuiMCP::ImVec2{ frameMax.x + 1, frameMax.y + 1 },
-                UI::Theme::Enjoyment::frameRim, 0.0f, 0, 1.0f);
+                UI::Theme::Enjoyment.frameRim, 0.0f, 0, 1.0f);
 
             // inner top shine
             ImGuiMCP::ImDrawListManager::AddLine(dl,
                 ImGuiMCP::ImVec2{ frameMin.x + 1, frameMin.y + 1 },
                 ImGuiMCP::ImVec2{ frameMax.x - 1, frameMin.y + 1 },
-                UI::Theme::Enjoyment::frameShine, 1.0f);
+                UI::Theme::Enjoyment.frameShine, 1.0f);
 
             // fill
             const float frac = FillFraction(b.enjoyment);
@@ -343,26 +343,26 @@ namespace Thread::Interface
 
                 ImGuiMCP::ImDrawListManager::AddRectFilled(dl,
                     ImGuiMCP::ImVec2{ gx0, frameMin.y }, ImGuiMCP::ImVec2{ gx1, frameMax.y },
-                    inZone ? UI::Theme::Enjoyment::zoneActive : UI::Theme::Enjoyment::zoneIdle, 0.0f, 0);
+                    inZone ? UI::Theme::Enjoyment.zoneActive : UI::Theme::Enjoyment.zoneIdle, 0.0f, 0);
                 ImGuiMCP::ImDrawListManager::AddLine(dl,
                     ImGuiMCP::ImVec2{ gx0, frameMin.y }, ImGuiMCP::ImVec2{ gx0, frameMax.y },
-                    inZone ? UI::Theme::Enjoyment::zoneFocused : UI::Theme::Enjoyment::zoneBorder, 1.0f);
+                    inZone ? UI::Theme::Enjoyment.zoneFocused : UI::Theme::Enjoyment.zoneBorder, 1.0f);
                 ImGuiMCP::ImDrawListManager::AddLine(dl,
                     ImGuiMCP::ImVec2{ gx1, frameMin.y }, ImGuiMCP::ImVec2{ gx1, frameMax.y },
-                    inZone ? UI::Theme::Enjoyment::zoneFocused : UI::Theme::Enjoyment::zoneBorder, 1.0f);
+                    inZone ? UI::Theme::Enjoyment.zoneFocused : UI::Theme::Enjoyment.zoneBorder, 1.0f);
 
                 // zone center line
                 const float zoneCx = (gx0 + gx1) * 0.5f;
                 ImGuiMCP::ImDrawListManager::AddLine(dl,
                     ImGuiMCP::ImVec2{ zoneCx, frameMin.y }, ImGuiMCP::ImVec2{ zoneCx, frameMax.y },
-                    inZone ? UI::Theme::Enjoyment::zoneCenterActive : UI::Theme::Enjoyment::zoneCenter, 1.0f);
+                    inZone ? UI::Theme::Enjoyment.zoneCenterActive : UI::Theme::Enjoyment.zoneCenter, 1.0f);
 
                 // needle rect
                 const float nx = frameMin.x + _needlePosition * zoneW;
                 const float nw = innerGp * 0.667f;
                 const float nTop = frameMin.y - innerGp * 0.667f;
                 const float nBot = frameMax.y + innerGp * 0.667f;
-                const ImGuiMCP::ImU32 nCol = inZone ? UI::Theme::Enjoyment::needleActive : UI::Theme::Enjoyment::needle;
+                const ImGuiMCP::ImU32 nCol = inZone ? UI::Theme::Enjoyment.needleActive : UI::Theme::Enjoyment.needle;
                 ImGuiMCP::ImDrawListManager::AddRectFilled(dl,
                     ImGuiMCP::ImVec2{ nx - nw * 0.5f, nTop }, ImGuiMCP::ImVec2{ nx + nw * 0.5f, nBot },
                     nCol, 0.0f, 0);
@@ -377,11 +377,11 @@ namespace Thread::Interface
                 // feedback flash
                 if (_feedbackActorId == b.formId && now < _feedbackUntil) {
                     ImGuiMCP::ImDrawListManager::AddRectFilled(dl, frameMin, frameMax,
-                        _feedbackHit ? UI::Theme::Enjoyment::feedbackHit : UI::Theme::Enjoyment::feedbackMiss,
+                        _feedbackHit ? UI::Theme::Enjoyment.feedbackHit : UI::Theme::Enjoyment.feedbackMiss,
                         0.0f, 0);
                     SetWindowFontSize(fbFt);
                     const char* fbStr = _feedbackHit ? "HIT" : "MISS";
-                    const ImGuiMCP::ImU32 fbCol = _feedbackHit ? UI::Theme::Enjoyment::hit : UI::Theme::Enjoyment::miss;
+                    const ImGuiMCP::ImU32 fbCol = _feedbackHit ? UI::Theme::Enjoyment.hit : UI::Theme::Enjoyment.miss;
                     const ImGuiMCP::ImVec2 fbSz = ImGuiMCP::CalcTextSize(fbStr);
                     DrawTextShadowed(dl,
                         ImGuiMCP::ImVec2{ frameMax.x - fbSz.x - innerGp * 1.667f,
@@ -394,7 +394,7 @@ namespace Thread::Interface
 
             // highlight border for whichever actor is currently targeted
             if (b.isTarget) {
-                constexpr auto tc = UI::Theme::Enjoyment::targetBorder;
+                const auto tc = UI::Theme::Enjoyment.targetBorder;
                 ImGuiMCP::ImDrawListManager::AddRect(dl, frameMin, frameMax, tc, 0.0f, 0, 1.0f);
                 ImGuiMCP::ImDrawListManager::AddRect(dl,
                     ImGuiMCP::ImVec2{ frameMin.x - 1, frameMin.y - 1 },

--- a/src/Thread/Interface/Elements/OffsetAdjustPanel.cpp
+++ b/src/Thread/Interface/Elements/OffsetAdjustPanel.cpp
@@ -196,7 +196,7 @@ namespace Thread::Interface
         const float labelTextH = ImGuiMCP::CalcTextSize(axisLabel).y;
         const ImGuiMCP::ImVec2 lblMin = { rowOrigin.x + rowPadH, rowCenterY - labelTextH * 0.5f };
         ImGuiMCP::SetCursorScreenPos(lblMin);
-        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "%s", axisLabel);
+        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "%s", axisLabel);
         const ImGuiMCP::ImVec2 lblMax = ImGuiMCP::ImVec2{ lblMin.x + ImGuiMCP::CalcTextSize(axisLabel).x, lblMin.y + labelTextH };
         if (ImGuiMCP::IsMouseHoveringRect(lblMin, lblMax) &&
             ImGuiMCP::IsMouseDoubleClicked(ImGuiMCP::ImGuiMouseButton_Left)) {
@@ -224,8 +224,8 @@ namespace Thread::Interface
         std::snprintf(valBuf, sizeof(valBuf),
             "%d", static_cast<int>(std::round(state.value)));
         ImGuiMCP::SetNextItemWidth(valW);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_FrameBg, UI::Theme::Color::transparent);
-        const ImGuiMCP::ImU32 valTextCol = UI::Theme::Color::textMuted;
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_FrameBg, UI::Theme::Color.transparent);
+        const ImGuiMCP::ImU32 valTextCol = UI::Theme::Color.textMuted;
         ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, valTextCol);
         ImGuiMCP::PushStyleVar(ImGuiMCP::ImGuiStyleVar_FrameRounding, a_scale.Px(UI::Theme::Geometry::roundingSmall));
         if (ImGuiMCP::InputText("##slpp_oamVal", valBuf, sizeof(valBuf),
@@ -290,14 +290,14 @@ namespace Thread::Interface
         auto* dl = ImGuiMCP::GetWindowDrawList();
 
         // Track background
-        ImGuiMCP::ImDrawListManager::AddRectFilled(dl, trackMin, trackMax, UI::Theme::Offset::track, a_scale.Px(2.0f), 0);
-        ImGuiMCP::ImDrawListManager::AddRect(dl, trackMin, trackMax, UI::Theme::Offset::trackBorder, a_scale.Px(2.0f), 0, 1.0f);
+        ImGuiMCP::ImDrawListManager::AddRectFilled(dl, trackMin, trackMax, UI::Theme::Offset.track, a_scale.Px(2.0f), 0);
+        ImGuiMCP::ImDrawListManager::AddRect(dl, trackMin, trackMax, UI::Theme::Offset.trackBorder, a_scale.Px(2.0f), 0, 1.0f);
 
         // Center tick
         const float cx = trackMin.x + trackW * 0.5f;
         ImGuiMCP::ImDrawListManager::AddLine(dl,
             ImGuiMCP::ImVec2{ cx, trackMin.y - a_scale.Px(2.0f) }, ImGuiMCP::ImVec2{ cx, trackMax.y + a_scale.Px(2.0f) },
-            UI::Theme::Offset::centerTick, 1.0f);
+            UI::Theme::Offset.centerTick, 1.0f);
 
         // Fill grows from the center out toward the needle, in either direction.
         const float pct = std::clamp(0.5f + (state.value / range) * 0.5f, 0.0f, 1.0f);
@@ -307,13 +307,13 @@ namespace Thread::Interface
             const float fillR = std::max(cx, needleX);
             ImGuiMCP::ImDrawListManager::AddRectFilled(dl,
                 ImGuiMCP::ImVec2{ fillL, trackMin.y }, ImGuiMCP::ImVec2{ fillR, trackMax.y },
-                UI::Theme::Offset::fill, 0.0f, 0);
+                UI::Theme::Offset.fill, 0.0f, 0);
         }
 
         // Needle extends slightly above and below the track so it stays visible
         const float nTop = trackMin.y - a_scale.Px(5.0f);
         const float nBot = trackMax.y + a_scale.Px(5.0f);
-        const ImGuiMCP::ImU32 nCol = active ? UI::Theme::Offset::needleActive : UI::Theme::Offset::needle;
+        const ImGuiMCP::ImU32 nCol = active ? UI::Theme::Offset.needleActive : UI::Theme::Offset.needle;
         ImGuiMCP::ImDrawListManager::AddRectFilled(dl,
             ImGuiMCP::ImVec2{ needleX - needleW * 0.5f, nTop },
             ImGuiMCP::ImVec2{ needleX + needleW * 0.5f, nBot },
@@ -324,7 +324,7 @@ namespace Thread::Interface
         ImGuiMCP::ImDrawListManager::AddLine(dl,
             ImGuiMCP::ImVec2{ rowOrigin.x + rowPadH, sepPos.y },
             ImGuiMCP::ImVec2{ rowOrigin.x + rowPadH + availW, sepPos.y },
-            UI::Theme::Offset::separator, 1.0f);
+            UI::Theme::Offset.separator, 1.0f);
 
         return changed;
     }
@@ -357,7 +357,7 @@ namespace Thread::Interface
                 SetWindowFontSize(scale.TextPx(UI::Theme::FontSize::sectionHeader));
                 const float titleW = ImGuiMCP::CalcTextSize("PICK TARGET").x;
                 ImGuiMCP::SetCursorPosX((pickerW - titleW) * 0.5f);
-                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textPrimary), "PICK TARGET");
+                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textPrimary), "PICK TARGET");
                 ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(4.0f) });
                 ImGuiMCP::Separator();
 
@@ -372,7 +372,7 @@ namespace Thread::Interface
                             lbl += " [SCENE]";
 
                         if (isSel)
-                            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Header, UI::Theme::Color::selectionFill);
+                            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Header, UI::Theme::Color.selectionFill);
                         if (UI::SelectableButton(lbl.c_str(), isSel, 0, ImGuiMCP::ImVec2{ 0, scale.Px(28.0f) }))
                             OnActorSelected(a_hud, item);
                         if (isSel)
@@ -415,7 +415,7 @@ namespace Thread::Interface
                 SetWindowFontSize(scale.TextPx(UI::Theme::FontSize::sectionHeader));
                 const float titleW = ImGuiMCP::CalcTextSize(panelTitle.c_str()).x;
                 ImGuiMCP::SetCursorPosX((panelW - titleW) * 0.5f);
-                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textPrimary), "%s", panelTitle.c_str());
+                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textPrimary), "%s", panelTitle.c_str());
                 ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(4.0f) });
                 ImGuiMCP::Separator();
 
@@ -428,7 +428,7 @@ namespace Thread::Interface
                 const float availW = ImGuiMCP::GetContentRegionAvail().x - rowPadH * 2.0f;
                 const ImGuiMCP::ImVec2 toggleRowMin = ImGuiMCP::GetCursorScreenPos();
                 ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x + rowPadH, toggleRowMin.y });
-                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::ToVec4(UI::Theme::Color::transparent));
+                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::ToVec4(UI::Theme::Color.transparent));
                 if (UI::SelectableButton("##slpp_stageOnlyRow", false, 0, ImGuiMCP::ImVec2{ availW, toggleRowH })) {
                     OnSetAdjustStageOnly(a_hud, !_adjustStageOnly);
                 }
@@ -448,10 +448,10 @@ namespace Thread::Interface
                 const ImGuiMCP::ImVec2 labelSize = ImGuiMCP::CalcTextSize("Adjust Stage Only");
                 const float labelY = toggleRowMin.y + (toggleRowH - labelSize.y) * 0.5f;
                 ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x + rowPadH, labelY });
-                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "Adjust Stage Only");
+                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "Adjust Stage Only");
                 ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x, toggleRowMin.y + toggleRowH });
 
-                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Separator, UI::Theme::Offset::separator);
+                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Separator, UI::Theme::Offset.separator);
                 ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(6.0f) });
                 ImGuiMCP::Separator();
                 ImGuiMCP::PopStyleColor();

--- a/src/Thread/Interface/Elements/PseudoPanelStack.cpp
+++ b/src/Thread/Interface/Elements/PseudoPanelStack.cpp
@@ -90,9 +90,9 @@ namespace Thread::Interface
             const ImGuiMCP::ImVec2 tMin = ImGuiMCP::GetCursorScreenPos();
             const ImGuiMCP::ImVec2 tMax{ tMin.x + tabW, tMin.y + tabH };
 
-            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Header, UI::Theme::Color::transparent);
-            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::Color::transparent);
-            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderActive, UI::Theme::Color::transparent);
+            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Header, UI::Theme::Color.transparent);
+            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::Color.transparent);
+            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderActive, UI::Theme::Color.transparent);
             const bool clicked = ImGuiMCP::Selectable("##slpp_ppsTab", isActiveTab, 0, ImGuiMCP::ImVec2{ tabW, tabH });
             const bool highlighted = ImGuiMCP::IsItemHovered() || ImGuiMCP::IsItemFocused();
             const bool pressed = ImGuiMCP::IsItemActive();
@@ -101,19 +101,19 @@ namespace Thread::Interface
 
             const float rounding = scale.Px(UI::Theme::Geometry::roundingPanel);
             const auto roundLeft = ImGuiMCP::ImDrawFlags_RoundCornersLeft;
-            const auto background = isActiveTab ? UI::Theme::Color::surfaceActive :
-                                    pressed     ? UI::Theme::Color::surfacePressed :
-                                    highlighted ? UI::Theme::Color::surfaceHovered :
-                                                  UI::Theme::Color::surfacePanel;
-            const auto border = isActiveTab ? UI::Theme::Color::borderActive :
-                                highlighted ? UI::Theme::Color::borderHovered :
-                                              UI::Theme::Color::borderSubtle;
-            const auto text = isActiveTab || highlighted ? UI::Theme::Color::textPrimary : UI::Theme::Color::textSecondary;
+            const auto background = isActiveTab ? UI::Theme::Color.surfaceActive :
+                                    pressed     ? UI::Theme::Color.surfacePressed :
+                                    highlighted ? UI::Theme::Color.surfaceHovered :
+                                                  UI::Theme::Color.surfacePanel;
+            const auto border = isActiveTab ? UI::Theme::Color.borderActive :
+                                highlighted ? UI::Theme::Color.borderHovered :
+                                              UI::Theme::Color.borderSubtle;
+            const auto text = isActiveTab || highlighted ? UI::Theme::Color.textPrimary : UI::Theme::Color.textSecondary;
 
             ImGuiMCP::ImDrawListManager::AddRectFilled(dl,
                 ImGuiMCP::ImVec2{ tMin.x - scale.Px(1.0f), tMin.y + scale.Px(1.0f) },
                 ImGuiMCP::ImVec2{ tMax.x, tMax.y + scale.Px(1.0f) },
-                UI::Theme::Color::shadowSoft, rounding, roundLeft);
+                UI::Theme::Color.shadowSoft, rounding, roundLeft);
             ImGuiMCP::ImDrawListManager::AddRectFilled(dl, tMin, tMax, background, rounding, roundLeft);
             ImGuiMCP::ImDrawListManager::AddRect(dl, tMin, tMax, border, rounding, roundLeft,
                 scale.Px(UI::Theme::Geometry::borderThin));
@@ -122,7 +122,7 @@ namespace Thread::Interface
             ImGuiMCP::ImDrawListManager::AddLine(dl,
                 ImGuiMCP::ImVec2{ tMin.x + accentW * 0.5f, tMin.y + rounding },
                 ImGuiMCP::ImVec2{ tMin.x + accentW * 0.5f, tMax.y - rounding },
-                isActiveTab ? UI::Theme::Color::accent : border, accentW);
+                isActiveTab ? UI::Theme::Color.accent : border, accentW);
 
             const ImGuiMCP::ImVec2 lblSz = ImGuiMCP::CalcTextSize(kTabs[index].label);
             const ImGuiMCP::ImVec2 lblPos{ tMin.x + scale.Px(13.0f), tMin.y + (tabH - lblSz.y) * 0.5f };

--- a/src/Thread/Interface/Elements/PseudoPanelStack.cpp
+++ b/src/Thread/Interface/Elements/PseudoPanelStack.cpp
@@ -101,10 +101,10 @@ namespace Thread::Interface
 
             const float rounding = scale.Px(UI::Theme::Geometry::roundingPanel);
             const auto roundLeft = ImGuiMCP::ImDrawFlags_RoundCornersLeft;
-            const auto background = isActiveTab ? UI::Theme::Color.surfaceActive :
-                                    pressed     ? UI::Theme::Color.surfacePressed :
-                                    highlighted ? UI::Theme::Color.surfaceHovered :
-                                                  UI::Theme::Color.surfacePanel;
+            const auto background = isActiveTab ? UI::Theme::Color.buttonSelected :
+                                    pressed     ? UI::Theme::Color.buttonPressed :
+                                    highlighted ? UI::Theme::Color.buttonHovered :
+                                                  UI::Theme::Color.buttonIdle;
             const auto border = isActiveTab ? UI::Theme::Color.borderActive :
                                 highlighted ? UI::Theme::Color.borderHovered :
                                               UI::Theme::Color.borderSubtle;

--- a/src/Thread/Interface/Elements/SceneSelectPanel.cpp
+++ b/src/Thread/Interface/Elements/SceneSelectPanel.cpp
@@ -195,10 +195,10 @@ namespace Thread::Interface
 
         // Modern scrollbar styling
         ImGuiMCP::PushStyleVar(ImGuiMCP::ImGuiStyleVar_ScrollbarSize, scale.Px(6.0f));
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarBg, UI::Theme::Color::surfacePanel);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrab, UI::Theme::ToVec4(UI::Theme::Color::borderSubtle));
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabHovered, UI::Theme::ToVec4(UI::Theme::Color::borderHovered));
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabActive, UI::Theme::ToVec4(UI::Theme::Color::borderActive));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarBg, UI::Theme::Color.surfacePanel);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrab, UI::Theme::ToVec4(UI::Theme::Color.borderSubtle));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabHovered, UI::Theme::ToVec4(UI::Theme::Color.borderHovered));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabActive, UI::Theme::ToVec4(UI::Theme::Color.borderActive));
 
         ImGuiMCP::BeginChild("##slpp_smmSceneList", ImGuiMCP::ImVec2{ panelW - panelPadding * 2.0f, calculatedListH },
             ImGuiMCP::ImGuiChildFlags_None, ImGuiMCP::ImGuiWindowFlags_None);
@@ -210,9 +210,9 @@ namespace Thread::Interface
             ImGuiMCP::PushID(i);
 
             if (e.isActive)
-                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::Color::accent);
+                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::Color.accent);
             else
-                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color::textSecondary));
+                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textSecondary));
 
             ImGuiMCP::SetCursorPosX(ImGuiMCP::GetCursorPosX() + scale.Px(8.0f));
             const bool clicked = UI::SelectableButton(e.name.c_str(), e.isActive,
@@ -246,7 +246,7 @@ namespace Thread::Interface
         const float inputW = searchAreaW - btnTextW - scale.Px(8.0f);
 
         // Style search input
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color::textSecondary));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textSecondary));
         SetWindowFontSize(scale.TextPx(UI::Theme::FontSize::caption));
 
         ImGuiMCP::SetNextItemWidth(inputW);
@@ -320,10 +320,10 @@ namespace Thread::Interface
                 SetWindowFontSize(keyFont);
 
                 auto infoRow = [&](const char* key, const std::string& val, float valFont) {
-                    ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "%s", key);
+                    ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "%s", key);
                     ImGuiMCP::SameLine(keyW);
                     SetWindowFontSize(valFont);
-                    ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textMuted), "%s",
+                    ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textMuted), "%s",
                         val.empty() ? "\xE2\x80\x94" : val.c_str());
                     SetWindowFontSize(keyFont);
                     ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, rowGap });
@@ -332,16 +332,16 @@ namespace Thread::Interface
                 infoRow("PACK:", e.packageName, rowFont);
                 infoRow("AUTHOR:", e.author, rowFont);
 
-                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "TAGS:");
+                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "TAGS:");
                 ImGuiMCP::SameLine(keyW);
                 SetWindowFontSize(tagFont);
-                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color::textMuted));
+                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textMuted));
                 ImGuiMCP::TextWrapped("%s", e.tags.empty() ? "\xE2\x80\x94" : e.tags.c_str());
                 ImGuiMCP::PopStyleColor();
                 SetWindowFontSize(keyFont);
                 ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, rowGap });
 
-                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "ANNOTATIONS");
+                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "ANNOTATIONS");
                 SetWindowFontSize(rowFont);
                 const float fieldW = cardW - scale.Px(12.0f);
                 const ImGuiMCP::ImVec2 annotSz{ fieldW,

--- a/src/Thread/Interface/Elements/SceneSelectPanel.cpp
+++ b/src/Thread/Interface/Elements/SceneSelectPanel.cpp
@@ -195,7 +195,7 @@ namespace Thread::Interface
 
         // Modern scrollbar styling
         ImGuiMCP::PushStyleVar(ImGuiMCP::ImGuiStyleVar_ScrollbarSize, scale.Px(6.0f));
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarBg, UI::Theme::Color.surfacePanel);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarBg, UI::Theme::Color.panelBackground);
         ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrab, UI::Theme::ToVec4(UI::Theme::Color.borderSubtle));
         ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabHovered, UI::Theme::ToVec4(UI::Theme::Color.borderHovered));
         ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabActive, UI::Theme::ToVec4(UI::Theme::Color.borderActive));

--- a/src/Thread/Interface/Elements/ThreadConfigPanel.cpp
+++ b/src/Thread/Interface/Elements/ThreadConfigPanel.cpp
@@ -144,9 +144,9 @@ namespace Thread::Interface
         const ImGuiMCP::ImVec2 hdrMin = ImGuiMCP::GetCursorScreenPos();
         const float hdrH = subsectionHeaderSize + hdrPadV * 2.0f;
 
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Header, UI::Theme::Color::nestedHeader);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::Color::nestedHeaderHovered);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderActive, UI::Theme::Color::nestedControlActive);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Header, UI::Theme::Color.nestedHeader);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::Color.nestedHeaderHovered);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderActive, UI::Theme::Color.nestedControlActive);
         if (ImGuiMCP::Selectable("##slpp_tcmCardHdr", false, 0, ImGuiMCP::ImVec2{ cardW, hdrH }))
             state.cardOpen = !state.cardOpen;
         ImGuiMCP::PopStyleColor(3);
@@ -156,7 +156,7 @@ namespace Thread::Interface
         auto* dl = ImGuiMCP::GetWindowDrawList();
         if (!hdrHov) {
             const ImGuiMCP::ImVec2 hdrMax{ hdrMin.x + cardW, hdrMin.y + hdrH };
-            ImGuiMCP::ImDrawListManager::AddRectFilled(dl, hdrMin, hdrMax, UI::Theme::Color::nestedHeader, 0.0f, 0);
+            ImGuiMCP::ImDrawListManager::AddRectFilled(dl, hdrMin, hdrMax, UI::Theme::Color.nestedHeader, 0.0f, 0);
         }
 
         ImGuiMCP::SetCursorScreenPos(hdrMin);
@@ -167,11 +167,11 @@ namespace Thread::Interface
         ImGuiMCP::ImDrawListManager::AddRectFilled(dl,
             ImGuiMCP::ImVec2{ hdrMin.x, hdrMin.y },
             ImGuiMCP::ImVec2{ hdrMin.x + accentBarW, hdrMin.y + hdrH },
-            hdrHov ? UI::Theme::Color::accent : UI::Theme::Color::borderSubtle, 0.0f, 0);
+            hdrHov ? UI::Theme::Color.accent : UI::Theme::Color.borderSubtle, 0.0f, 0);
 
         // Name at left with padding
         ImGuiMCP::SetCursorScreenPos(ImGuiMCP::ImVec2{ hdrMin.x + hdrPadH, hdrMin.y + hdrPadV });
-        ImGuiMCP::TextColored(UI::Theme::ToVec4(hdrHov ? UI::Theme::Color::textPrimary : UI::Theme::Color::textSecondary),
+        ImGuiMCP::TextColored(UI::Theme::ToVec4(hdrHov ? UI::Theme::Color.textPrimary : UI::Theme::Color.textSecondary),
             "%s", actor->GetDisplayFullName());
 
         // Right side: PLAYER badge then toggle icon, both flush-right
@@ -185,11 +185,11 @@ namespace Thread::Interface
             const ImGuiMCP::ImVec2 badgeSize = ImGuiMCP::CalcTextSize("PLAYER");
             const float badgeX = toggleIconX - fieldGap - badgeSize.x;
             ImGuiMCP::SetCursorScreenPos(ImGuiMCP::ImVec2{ badgeX, hdrMin.y + hdrPadV });
-            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::accent), "PLAYER");
+            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.accent), "PLAYER");
         }
         SKSEMenuFramework::PushFont(UI::Theme::Icon::solidFont);
         ImGuiMCP::SetCursorScreenPos(ImGuiMCP::ImVec2{ toggleIconX, hdrMin.y + hdrPadV });
-        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "%s", toggleIcon);
+        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "%s", toggleIcon);
         FontAwesome::Pop();
 
         ImGuiMCP::SetCursorScreenPos(ImGuiMCP::ImVec2{ hdrMin.x, hdrMin.y + hdrH });
@@ -208,12 +208,12 @@ namespace Thread::Interface
         ImGuiMCP::ImDrawListManager::ChannelsSplit(dl, 2);
         ImGuiMCP::ImDrawListManager::ChannelsSetCurrent(dl, 1);
 
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_FrameBg, UI::Theme::Color::nestedControl);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_FrameBgHovered, UI::Theme::Color::nestedControlHovered);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_FrameBgActive, UI::Theme::Color::nestedControlActive);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Button, UI::Theme::Color::nestedControl);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ButtonHovered, UI::Theme::Color::nestedControlHovered);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ButtonActive, UI::Theme::Color::nestedControlActive);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_FrameBg, UI::Theme::Color.nestedControl);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_FrameBgHovered, UI::Theme::Color.nestedControlHovered);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_FrameBgActive, UI::Theme::Color.nestedControlActive);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Button, UI::Theme::Color.nestedControl);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ButtonHovered, UI::Theme::Color.nestedControlHovered);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ButtonActive, UI::Theme::Color.nestedControlActive);
         SetWindowFontSize(scale.TextPx(UI::Theme::FontSize::compact) * nestedScale);
 
         // ── Expression combo
@@ -224,13 +224,13 @@ namespace Thread::Interface
 
             ImGuiMCP::SetCursorPosX(cardX + rowPadH);
             SetWindowFontSize(captionSize);
-            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "Expression");
+            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "Expression");
             ImGuiMCP::SameLine(fieldX);
 
             SetWindowFontSize(captionSize);
             ImGuiMCP::SetNextItemWidth(fieldW);
-            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_PopupBg, UI::Theme::Color::nestedPopup);
-            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color::textMuted));
+            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_PopupBg, UI::Theme::Color.nestedPopup);
+            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textMuted));
             if (ImGuiMCP::BeginCombo("##slpp_tcmExpr", curLabel.c_str())) {
                 ImGuiMCP::PopStyleColor();
                 lib->ForEachExpression([&](const auto& expr) {
@@ -240,9 +240,9 @@ namespace Thread::Interface
                     SKSE::Translation::Translate(label, label);
                     const bool sel = curExpr && curExpr->GetId() == expr.GetId();
                     if (sel)
-                        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::Color::selectionText);
+                        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::Color.selectionText);
                     else
-                        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color::textMuted));
+                        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textMuted));
                     SetWindowFontSize(captionSize);
                     if (ImGuiMCP::Selectable(label.c_str(), sel)) {
                         OnSetExpression(a_hud, actor, &expr);
@@ -267,13 +267,13 @@ namespace Thread::Interface
 
             ImGuiMCP::SetCursorPosX(cardX + rowPadH);
             SetWindowFontSize(captionSize);
-            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "Voice");
+            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "Voice");
             ImGuiMCP::SameLine(fieldX);
 
             SetWindowFontSize(captionSize);
             ImGuiMCP::SetNextItemWidth(fieldW);
-            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_PopupBg, UI::Theme::Color::nestedPopup);
-            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color::textMuted));
+            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_PopupBg, UI::Theme::Color.nestedPopup);
+            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textMuted));
             if (ImGuiMCP::BeginCombo("##slpp_tcmVoice", curLabel.c_str())) {
                 ImGuiMCP::PopStyleColor();
                 lib->ForEachVoice([&](const auto& v) {
@@ -283,9 +283,9 @@ namespace Thread::Interface
                     SKSE::Translation::Translate(label, label);
                     const bool sel = curVoice && curVoice->GetId() == v.GetId();
                     if (sel)
-                        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::Color::selectionText);
+                        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::Color.selectionText);
                     else
-                        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color::textMuted));
+                        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textMuted));
                     SetWindowFontSize(captionSize);
                     if (ImGuiMCP::Selectable(label.c_str(), sel)) {
                         OnSetVoice(a_hud, actor, &v);
@@ -307,7 +307,7 @@ namespace Thread::Interface
 
             ImGuiMCP::SetCursorPosX(cardX + rowPadH);
             SetWindowFontSize(captionSize);
-            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "Alpha");
+            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "Alpha");
             ImGuiMCP::SameLine(fieldX);
 
             ImGuiMCP::SetNextItemWidth(alphaW);
@@ -320,7 +320,7 @@ namespace Thread::Interface
 
             ImGuiMCP::SameLine(0.0f, fieldGap);
             SetWindowFontSize(captionSize);
-            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textMuted), "%d%%", alphaInt);
+            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textMuted), "%d%%", alphaInt);
         }
 
         // ── Scene position row
@@ -344,14 +344,14 @@ namespace Thread::Interface
                 ImGuiMCP::SetCursorPosX(cardX + rowPadH);
 
                 // Label (left)
-                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "Scene Position");
+                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "Scene Position");
 
                 // Count (center, same line)
                 const float permTextW = ImGuiMCP::CalcTextSize(permBuf).x;
                 const float centerX = cardX + cardW * 0.5f - permTextW * 0.5f;
                 ImGuiMCP::SameLine();
                 ImGuiMCP::SetCursorPosX(centerX);
-                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textMuted), "%s", permBuf);
+                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textMuted), "%s", permBuf);
 
                 // Next-perm button (right, same line)
                 const float rightBtnX = cardX + cardW - rowPadH - btnRoundedW;
@@ -375,7 +375,7 @@ namespace Thread::Interface
         const ImGuiMCP::ImVec2 bodyMax{ hdrMin.x + cardW, ImGuiMCP::GetCursorScreenPos().y };
         ImGuiMCP::ImDrawListManager::ChannelsSetCurrent(dl, 0);
         ImGuiMCP::ImDrawListManager::AddRectFilled(
-            dl, bodyMin, bodyMax, UI::Theme::Color::nestedSurface, 0.0f, 0);
+            dl, bodyMin, bodyMax, UI::Theme::Color.nestedSurface, 0.0f, 0);
         ImGuiMCP::ImDrawListManager::ChannelsMerge(dl);
 
         ImGuiMCP::SetCursorPosX(contentX);
@@ -424,7 +424,7 @@ namespace Thread::Interface
         const ImGuiMCP::ImVec2 toggleRowMin = ImGuiMCP::GetCursorScreenPos();
         ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x + rowPadH, toggleRowMin.y });
 
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::ToVec4(UI::Theme::Color::transparent));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::ToVec4(UI::Theme::Color.transparent));
         if (UI::SelectableButton("##slpp_autoAdvanceRow", false, 0, ImGuiMCP::ImVec2{ availW, toggleRowH })) {
             bool autoPlay = inst->GetThreadProperty<bool>("AutoAdvance");
             OnAutoPlaySet(a_hud, !autoPlay);
@@ -445,7 +445,7 @@ namespace Thread::Interface
         const ImGuiMCP::ImVec2 labelSize = ImGuiMCP::CalcTextSize("Auto Advance");
         const float labelY = toggleRowMin.y + (toggleRowH - labelSize.y) * 0.5f;
         ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x + rowPadH, labelY });
-        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "Auto Advance");
+        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "Auto Advance");
         ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x, toggleRowMin.y + toggleRowH });
 
         ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(UI::Theme::Spacing::md) });
@@ -455,7 +455,7 @@ namespace Thread::Interface
         const float actionGap = scale.Px(UI::Theme::Spacing::sm);
         const float actionW = (panelW - rowPadH * 2.0f - actionGap) * 0.5f;
         ImGuiMCP::SetCursorPosX(rowPadH);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color::textSecondary));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::ToVec4(UI::Theme::Color.textSecondary));
         if (UI::ActionButton("Random Scene", actionW))
             OnRandomScene(a_hud);
         ImGuiMCP::SameLine(0.0f, actionGap);
@@ -463,7 +463,7 @@ namespace Thread::Interface
             OnMoveScene(a_hud);
         ImGuiMCP::PopStyleColor();
 
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Separator, UI::Theme::Color::nestedSeparator);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Separator, UI::Theme::Color.nestedSeparator);
         ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(UI::Theme::Spacing::sm) });
         ImGuiMCP::Separator();
         ImGuiMCP::PopStyleColor();
@@ -472,16 +472,16 @@ namespace Thread::Interface
         ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(UI::Theme::Spacing::xs) });
 
         ImGuiMCP::PushStyleVar(ImGuiMCP::ImGuiStyleVar_ScrollbarSize, scale.Px(6.0f));
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarBg, UI::Theme::Color::surfacePanel);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrab, UI::Theme::ToVec4(UI::Theme::Color::borderSubtle));
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabHovered, UI::Theme::ToVec4(UI::Theme::Color::borderHovered));
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabActive, UI::Theme::ToVec4(UI::Theme::Color::borderActive));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarBg, UI::Theme::Color.surfacePanel);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrab, UI::Theme::ToVec4(UI::Theme::Color.borderSubtle));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabHovered, UI::Theme::ToVec4(UI::Theme::Color.borderHovered));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabActive, UI::Theme::ToVec4(UI::Theme::Color.borderActive));
 
         ImGuiMCP::SetNextWindowSizeConstraints(
             ImGuiMCP::ImVec2{ 0.0f, 0.0f }, ImGuiMCP::ImVec2{ FLT_MAX, maxBodyH });
         ImGuiMCP::BeginChild("##slpp_tcmActors", ImGuiMCP::ImVec2{ -FLT_MIN, 0.0f },
             ImGuiMCP::ImGuiChildFlags_AutoResizeY, ImGuiMCP::ImGuiWindowFlags_None);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Separator, UI::Theme::Color::nestedSeparator);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Separator, UI::Theme::Color.nestedSeparator);
 
         bool first = true;
         for (auto* actor : _sortedActors) {

--- a/src/Thread/Interface/Elements/ThreadConfigPanel.cpp
+++ b/src/Thread/Interface/Elements/ThreadConfigPanel.cpp
@@ -472,7 +472,7 @@ namespace Thread::Interface
         ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(UI::Theme::Spacing::xs) });
 
         ImGuiMCP::PushStyleVar(ImGuiMCP::ImGuiStyleVar_ScrollbarSize, scale.Px(6.0f));
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarBg, UI::Theme::Color.surfacePanel);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarBg, UI::Theme::Color.panelBackground);
         ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrab, UI::Theme::ToVec4(UI::Theme::Color.borderSubtle));
         ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabHovered, UI::Theme::ToVec4(UI::Theme::Color.borderHovered));
         ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabActive, UI::Theme::ToVec4(UI::Theme::Color.borderActive));

--- a/src/Thread/Interface/FurnSelectMenu.cpp
+++ b/src/Thread/Interface/FurnSelectMenu.cpp
@@ -84,7 +84,7 @@ namespace Thread::Interface
         SetWindowFontSize(scale.TextPx(UI::Theme::FontSize::sectionHeader));
         const char* title = "SELECT SCENE CENTER";
         ImGuiMCP::SetCursorPosX((panelW - ImGuiMCP::CalcTextSize(title).x) * 0.5f);
-        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textSecondary), "%s", title);
+        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "%s", title);
         ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(2.0f) });
         ImGuiMCP::Separator();
         ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(2.0f) });
@@ -94,7 +94,7 @@ namespace Thread::Interface
 
         if (_items.empty()) {
             ImGuiMCP::SetCursorPosX(padH);
-            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textMuted), "No suitable scene center nearby.");
+            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textMuted), "No suitable scene center nearby.");
         } else {
             const float innerW = panelW - padH * 2.0f;
 
@@ -123,13 +123,13 @@ namespace Thread::Interface
 
                 ImGuiMCP::SetCursorScreenPos({ rowMin.x + padH, rowMin.y + padV });
                 ImGuiMCP::TextColored(
-                    UI::Theme::ToVec4(hov ? UI::Theme::Color::textPrimary : UI::Theme::Color::textSecondary),
+                    UI::Theme::ToVec4(hov ? UI::Theme::Color.textPrimary : UI::Theme::Color.textSecondary),
                     "%s", leftLabel.c_str());
 
                 if (!formId.empty()) {
                     const float fW = ImGuiMCP::CalcTextSize(formId.c_str()).x;
                     ImGuiMCP::SetCursorScreenPos({ rowMin.x + padH + innerW - fW - padH, rowMin.y + padV });
-                    ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color::textMuted), "%s", formId.c_str());
+                    ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textMuted), "%s", formId.c_str());
                 }
 
                 ImGuiMCP::SetCursorScreenPos({ rowMin.x, rowMin.y + rowH });

--- a/src/Thread/Interface/FurnSelectMenu.cpp
+++ b/src/Thread/Interface/FurnSelectMenu.cpp
@@ -74,8 +74,11 @@ namespace Thread::Interface
             ImGuiMCP::ImGuiWindowFlags_NoMove | ImGuiMCP::ImGuiWindowFlags_NoCollapse |
             ImGuiMCP::ImGuiWindowFlags_AlwaysAutoResize;
 
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_WindowBg, UI::Theme::Color.panelBackground);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Border, UI::Theme::Color.panelBorder);
         if (!ImGuiMCP::Begin("##slpp_FurnSelect", &isOpen, kFlags)) {
             ImGuiMCP::End();
+            ImGuiMCP::PopStyleColor(2);
             SetVisible(isOpen);
             return;
         }
@@ -140,6 +143,7 @@ namespace Thread::Interface
         ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(2.0f) });
         ImGuiMCP::SetWindowFontScale(1.0f);
         ImGuiMCP::End();
+        ImGuiMCP::PopStyleColor(2);
         SetVisible(isOpen);
         if (selectedIndex)
             HandleSelection(*selectedIndex);

--- a/src/Thread/Interface/SceneHUD.cpp
+++ b/src/Thread/Interface/SceneHUD.cpp
@@ -145,6 +145,7 @@ namespace Thread::Interface
         default:
             break;
         }
+        _elements->elementCtrlPanel.RenderColorEditor(*this);
     }
 
     void SceneHUD::SetFocus(bool a_focused)

--- a/src/Thread/Interface/SceneHUD.cpp
+++ b/src/Thread/Interface/SceneHUD.cpp
@@ -128,6 +128,11 @@ namespace Thread::Interface
         if (!_focused)
             return;
 
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_WindowBg, UI::Theme::Color.panelBackground);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Border, UI::Theme::Color.panelBorder);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Button, UI::Theme::Color.buttonIdle);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ButtonHovered, UI::Theme::Color.buttonHovered);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ButtonActive, UI::Theme::Color.buttonPressed);
         _elements->pseudoPanelStack.Render(*this);
         switch (_activePanel) {
         case PanelId::kThreadConfig:
@@ -146,6 +151,7 @@ namespace Thread::Interface
             break;
         }
         _elements->elementCtrlPanel.RenderColorEditor(*this);
+        ImGuiMCP::PopStyleColor(5);
     }
 
     void SceneHUD::SetFocus(bool a_focused)

--- a/src/Thread/Interface/UI/Theme.cpp
+++ b/src/Thread/Interface/UI/Theme.cpp
@@ -1,0 +1,91 @@
+#include "Theme.h"
+
+#include "Util/AsyncIO.h"
+
+#include <fstream>
+#include <optional>
+
+namespace Thread::Interface::UI::Theme
+{
+    namespace
+    {
+        constexpr auto THEME_PATH = USER_CONFIGS("ui_theme.json");
+
+        struct WriteOptions : glz::opts
+        {
+            bool prettify = true;
+            std::uint8_t indentation_width = 2;
+        };
+
+        bool loadComplete{ false };
+    }
+
+    void Load()
+    {
+        loadComplete = false;
+        Util::AsyncIO::Submit([]() {
+            std::optional<Data> loadedTheme;
+            std::error_code fileError;
+            if (fs::exists(THEME_PATH, fileError)) {
+                Data candidate{};
+                std::string buffer;
+                if (const auto error = glz::read_file_json(candidate, THEME_PATH, buffer); error) {
+                    logger::error("Unable to load UI theme: {}", glz::format_error(error, buffer));
+                } else {
+                    loadedTheme = candidate;
+                    logger::info("Loaded UI theme from {}", THEME_PATH);
+                }
+            } else if (fileError) {
+                logger::error("Unable to inspect UI theme path {}: {}", THEME_PATH, fileError.message());
+            } else {
+                loadedTheme.emplace();
+                logger::info("UI theme file not found; using defaults");
+            }
+
+            SKSE::GetTaskInterface()->AddTask([loadedTheme = std::move(loadedTheme)]() mutable {
+                if (loadedTheme)
+                    data = std::move(*loadedTheme);
+                loadComplete = true;
+            });
+        });
+    }
+
+    void Save()
+    {
+        if (!IsLoaded()) {
+            logger::warn("UI theme save ignored while the initial load is pending");
+            return;
+        }
+
+        auto snapshot = data;
+        Util::AsyncIO::Submit([snapshot = std::move(snapshot)]() {
+            const fs::path path{ THEME_PATH };
+            std::error_code directoryError;
+            fs::create_directories(path.parent_path(), directoryError);
+            if (directoryError) {
+                logger::error("Unable to create UI theme directory {}: {}", path.parent_path().string(), directoryError.message());
+                return;
+            }
+
+            std::string buffer;
+            if (const auto error = glz::write<WriteOptions{}>(snapshot, buffer); error) {
+                logger::error("Unable to serialize UI theme: {}", glz::format_error(error, buffer));
+                return;
+            }
+
+            std::ofstream output{ path, std::ios::binary | std::ios::trunc };
+            output.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+            output.close();
+            if (!output) {
+                logger::error("Unable to write UI theme to {}", THEME_PATH);
+                return;
+            }
+            logger::info("Saved UI theme to {}", THEME_PATH);
+        });
+    }
+
+    bool IsLoaded()
+    {
+        return loadComplete;
+    }
+}

--- a/src/Thread/Interface/UI/Theme.h
+++ b/src/Thread/Interface/UI/Theme.h
@@ -4,35 +4,35 @@
 
 namespace Thread::Interface::UI::Theme
 {
-    struct Color final
+    struct ColorValues final
     {
-        static constexpr ImGuiMCP::ImU32 textPrimary = IM_COL32(221, 216, 208, 255);
-        static constexpr ImGuiMCP::ImU32 textSecondary = IM_COL32(176, 168, 152, 255);
-        static constexpr ImGuiMCP::ImU32 textMuted = IM_COL32(136, 128, 120, 255);
-        static constexpr ImGuiMCP::ImU32 accent = IM_COL32(112, 184, 112, 255);
+        ImGuiMCP::ImU32 textPrimary = IM_COL32(221, 216, 208, 255);
+        ImGuiMCP::ImU32 textSecondary = IM_COL32(176, 168, 152, 255);
+        ImGuiMCP::ImU32 textMuted = IM_COL32(136, 128, 120, 255);
+        ImGuiMCP::ImU32 accent = IM_COL32(112, 184, 112, 255);
 
-        static constexpr ImGuiMCP::ImU32 surfacePanel = IM_COL32(20, 20, 22, 245);
-        static constexpr ImGuiMCP::ImU32 surfaceHovered = IM_COL32(36, 36, 40, 245);
-        static constexpr ImGuiMCP::ImU32 surfacePressed = IM_COL32(34, 34, 36, 245);
-        static constexpr ImGuiMCP::ImU32 surfaceActive = IM_COL32(22, 25, 23, 245);
-        static constexpr ImGuiMCP::ImU32 separator = IM_COL32(55, 55, 58, 128);
-        static constexpr ImGuiMCP::ImU32 shadow = IM_COL32(0, 0, 0, 210);
-        static constexpr ImGuiMCP::ImU32 shadowSoft = IM_COL32(0, 0, 0, 90);
-        static constexpr ImGuiMCP::ImU32 transparent = IM_COL32(0, 0, 0, 0);
-        static constexpr ImGuiMCP::ImU32 selectionText = IM_COL32(144, 176, 200, 255);
-        static constexpr ImGuiMCP::ImU32 selectionFill = IM_COL32(30, 40, 30, 128);
-        static constexpr ImGuiMCP::ImU32 nestedSurface = IM_COL32(10, 10, 10, 110);
-        static constexpr ImGuiMCP::ImU32 nestedHeader = IM_COL32(18, 18, 18, 180);
-        static constexpr ImGuiMCP::ImU32 nestedHeaderHovered = IM_COL32(30, 30, 30, 220);
-        static constexpr ImGuiMCP::ImU32 nestedControl = IM_COL32(10, 10, 10, 190);
-        static constexpr ImGuiMCP::ImU32 nestedControlHovered = IM_COL32(30, 30, 30, 225);
-        static constexpr ImGuiMCP::ImU32 nestedControlActive = IM_COL32(24, 24, 24, 235);
-        static constexpr ImGuiMCP::ImU32 nestedPopup = IM_COL32(14, 14, 14, 248);
-        static constexpr ImGuiMCP::ImU32 nestedSeparator = IM_COL32(92, 90, 86, 58);
+        ImGuiMCP::ImU32 surfacePanel = IM_COL32(20, 20, 22, 245);
+        ImGuiMCP::ImU32 surfaceHovered = IM_COL32(36, 36, 40, 245);
+        ImGuiMCP::ImU32 surfacePressed = IM_COL32(34, 34, 36, 245);
+        ImGuiMCP::ImU32 surfaceActive = IM_COL32(22, 25, 23, 245);
+        ImGuiMCP::ImU32 separator = IM_COL32(55, 55, 58, 128);
+        ImGuiMCP::ImU32 shadow = IM_COL32(0, 0, 0, 210);
+        ImGuiMCP::ImU32 shadowSoft = IM_COL32(0, 0, 0, 90);
+        ImGuiMCP::ImU32 transparent = IM_COL32(0, 0, 0, 0);
+        ImGuiMCP::ImU32 selectionText = IM_COL32(144, 176, 200, 255);
+        ImGuiMCP::ImU32 selectionFill = IM_COL32(30, 40, 30, 128);
+        ImGuiMCP::ImU32 nestedSurface = IM_COL32(10, 10, 10, 110);
+        ImGuiMCP::ImU32 nestedHeader = IM_COL32(18, 18, 18, 180);
+        ImGuiMCP::ImU32 nestedHeaderHovered = IM_COL32(30, 30, 30, 220);
+        ImGuiMCP::ImU32 nestedControl = IM_COL32(10, 10, 10, 190);
+        ImGuiMCP::ImU32 nestedControlHovered = IM_COL32(30, 30, 30, 225);
+        ImGuiMCP::ImU32 nestedControlActive = IM_COL32(24, 24, 24, 235);
+        ImGuiMCP::ImU32 nestedPopup = IM_COL32(14, 14, 14, 248);
+        ImGuiMCP::ImU32 nestedSeparator = IM_COL32(92, 90, 86, 58);
 
-        static constexpr ImGuiMCP::ImU32 borderSubtle = IM_COL32(92, 90, 86, 105);
-        static constexpr ImGuiMCP::ImU32 borderHovered = IM_COL32(145, 142, 136, 150);
-        static constexpr ImGuiMCP::ImU32 borderActive = IM_COL32(112, 184, 112, 220);
+        ImGuiMCP::ImU32 borderSubtle = IM_COL32(92, 90, 86, 105);
+        ImGuiMCP::ImU32 borderHovered = IM_COL32(145, 142, 136, 150);
+        ImGuiMCP::ImU32 borderActive = IM_COL32(112, 184, 112, 220);
     };
 
     struct FontSize final
@@ -83,50 +83,68 @@ namespace Thread::Interface::UI::Theme
         static constexpr float nestedMenuScale = 0.90f;
     };
 
-    struct Enjoyment final
+    struct EnjoymentValues final
     {
-        static constexpr ImGuiMCP::ImU32 normalLow = IM_COL32(122, 40, 40, 255);
-        static constexpr ImGuiMCP::ImU32 normalHigh = IM_COL32(208, 104, 88, 255);
-        static constexpr ImGuiMCP::ImU32 overflowLow = IM_COL32(138, 96, 16, 255);
-        static constexpr ImGuiMCP::ImU32 overflowHigh = IM_COL32(232, 184, 64, 255);
-        static constexpr ImGuiMCP::ImU32 negativeLow = IM_COL32(30, 58, 88, 255);
-        static constexpr ImGuiMCP::ImU32 negativeHigh = IM_COL32(72, 128, 192, 255);
-        static constexpr ImGuiMCP::ImU32 zoneIdle = IM_COL32(50, 155, 60, 41);
-        static constexpr ImGuiMCP::ImU32 zoneActive = IM_COL32(60, 185, 65, 71);
-        static constexpr ImGuiMCP::ImU32 zoneBorder = IM_COL32(90, 200, 70, 128);
-        static constexpr ImGuiMCP::ImU32 zoneFocused = IM_COL32(110, 250, 90, 242);
-        static constexpr ImGuiMCP::ImU32 needle = IM_COL32(200, 216, 184, 255);
-        static constexpr ImGuiMCP::ImU32 needleActive = IM_COL32(144, 248, 120, 255);
-        static constexpr ImGuiMCP::ImU32 hit = IM_COL32(96, 204, 80, 255);
-        static constexpr ImGuiMCP::ImU32 miss = IM_COL32(224, 96, 80, 255);
-        static constexpr ImGuiMCP::ImU32 frameSurface = IM_COL32(16, 16, 18, 255);
-        static constexpr ImGuiMCP::ImU32 frameBorder = IM_COL32(40, 40, 48, 255);
-        static constexpr ImGuiMCP::ImU32 frameRim = IM_COL32(255, 255, 255, 20);
-        static constexpr ImGuiMCP::ImU32 frameShine = IM_COL32(255, 255, 255, 10);
-        static constexpr ImGuiMCP::ImU32 zoneCenter = IM_COL32(80, 180, 60, 51);
-        static constexpr ImGuiMCP::ImU32 zoneCenterActive = IM_COL32(100, 230, 80, 77);
-        static constexpr ImGuiMCP::ImU32 feedbackHit = IM_COL32(60, 200, 80, 89);
-        static constexpr ImGuiMCP::ImU32 feedbackMiss = IM_COL32(200, 60, 40, 97);
-        static constexpr ImGuiMCP::ImU32 targetBorder = IM_COL32(106, 96, 85, 255);
+        ImGuiMCP::ImU32 normalLow = IM_COL32(122, 40, 40, 255);
+        ImGuiMCP::ImU32 normalHigh = IM_COL32(208, 104, 88, 255);
+        ImGuiMCP::ImU32 overflowLow = IM_COL32(138, 96, 16, 255);
+        ImGuiMCP::ImU32 overflowHigh = IM_COL32(232, 184, 64, 255);
+        ImGuiMCP::ImU32 negativeLow = IM_COL32(30, 58, 88, 255);
+        ImGuiMCP::ImU32 negativeHigh = IM_COL32(72, 128, 192, 255);
+        ImGuiMCP::ImU32 zoneIdle = IM_COL32(50, 155, 60, 41);
+        ImGuiMCP::ImU32 zoneActive = IM_COL32(60, 185, 65, 71);
+        ImGuiMCP::ImU32 zoneBorder = IM_COL32(90, 200, 70, 128);
+        ImGuiMCP::ImU32 zoneFocused = IM_COL32(110, 250, 90, 242);
+        ImGuiMCP::ImU32 needle = IM_COL32(200, 216, 184, 255);
+        ImGuiMCP::ImU32 needleActive = IM_COL32(144, 248, 120, 255);
+        ImGuiMCP::ImU32 hit = IM_COL32(96, 204, 80, 255);
+        ImGuiMCP::ImU32 miss = IM_COL32(224, 96, 80, 255);
+        ImGuiMCP::ImU32 frameSurface = IM_COL32(16, 16, 18, 255);
+        ImGuiMCP::ImU32 frameBorder = IM_COL32(40, 40, 48, 255);
+        ImGuiMCP::ImU32 frameRim = IM_COL32(255, 255, 255, 20);
+        ImGuiMCP::ImU32 frameShine = IM_COL32(255, 255, 255, 10);
+        ImGuiMCP::ImU32 zoneCenter = IM_COL32(80, 180, 60, 51);
+        ImGuiMCP::ImU32 zoneCenterActive = IM_COL32(100, 230, 80, 77);
+        ImGuiMCP::ImU32 feedbackHit = IM_COL32(60, 200, 80, 89);
+        ImGuiMCP::ImU32 feedbackMiss = IM_COL32(200, 60, 40, 97);
+        ImGuiMCP::ImU32 targetBorder = IM_COL32(106, 96, 85, 255);
     };
 
-    struct Offset final
+    struct OffsetValues final
     {
-        static constexpr ImGuiMCP::ImU32 fill = IM_COL32(160, 160, 160, 56);
-        static constexpr ImGuiMCP::ImU32 needle = IM_COL32(176, 168, 152, 255);
-        static constexpr ImGuiMCP::ImU32 needleActive = IM_COL32(221, 216, 208, 255);
-        static constexpr ImGuiMCP::ImU32 track = IM_COL32(255, 255, 255, 10);
-        static constexpr ImGuiMCP::ImU32 trackBorder = IM_COL32(58, 58, 58, 128);
-        static constexpr ImGuiMCP::ImU32 centerTick = IM_COL32(255, 255, 255, 26);
-        static constexpr ImGuiMCP::ImU32 separator = IM_COL32(38, 38, 38, 115);
+        ImGuiMCP::ImU32 fill = IM_COL32(160, 160, 160, 56);
+        ImGuiMCP::ImU32 needle = IM_COL32(176, 168, 152, 255);
+        ImGuiMCP::ImU32 needleActive = IM_COL32(221, 216, 208, 255);
+        ImGuiMCP::ImU32 track = IM_COL32(255, 255, 255, 10);
+        ImGuiMCP::ImU32 trackBorder = IM_COL32(58, 58, 58, 128);
+        ImGuiMCP::ImU32 centerTick = IM_COL32(255, 255, 255, 26);
+        ImGuiMCP::ImU32 separator = IM_COL32(38, 38, 38, 115);
     };
 
-    struct Animation final
+    struct AnimationValues final
     {
-        static constexpr ImGuiMCP::ImU32 timerTrack = IM_COL32(10, 10, 12, 178);
-        static constexpr ImGuiMCP::ImU32 timerEdge = IM_COL32(255, 255, 255, 38);
-        static constexpr ImGuiMCP::ImU32 timerCenter = IM_COL32(255, 255, 255, 217);
+        ImGuiMCP::ImU32 timerTrack = IM_COL32(10, 10, 12, 178);
+        ImGuiMCP::ImU32 timerEdge = IM_COL32(255, 255, 255, 38);
+        ImGuiMCP::ImU32 timerCenter = IM_COL32(255, 255, 255, 217);
     };
+
+    struct Data final
+    {
+        ColorValues color{};
+        EnjoymentValues enjoyment{};
+        OffsetValues offset{};
+        AnimationValues animation{};
+    };
+
+    inline Data data{};
+    inline auto& Color = data.color;
+    inline auto& Enjoyment = data.enjoyment;
+    inline auto& Offset = data.offset;
+    inline auto& Animation = data.animation;
+
+    void Load();
+    void Save();
+    [[nodiscard]] bool IsLoaded();
 
     inline ImGuiMCP::ImVec4 ToVec4(ImGuiMCP::ImU32 a_color)
     {
@@ -179,7 +197,7 @@ namespace Thread::Interface::UI
         const bool hovered = ImGuiMCP::IsItemHovered();
         const ImGuiMCP::ImVec2 cursorAfter = ImGuiMCP::GetCursorPos();
         const ImGuiMCP::ImVec2 labelSize = ImGuiMCP::CalcTextSize(a_label);
-        const ImGuiMCP::ImVec4 color = Theme::ToVec4(hovered ? Theme::Color::textPrimary : Theme::Color::textSecondary);
+        const ImGuiMCP::ImVec4 color = Theme::ToVec4(hovered ? Theme::Color.textPrimary : Theme::Color.textSecondary);
         const float horizontalPadding = a_size.y * 0.5f;
 
         ImGuiMCP::SetCursorScreenPos({ headerMin.x + horizontalPadding, headerMin.y + (a_size.y - labelSize.y) * 0.5f });
@@ -201,10 +219,10 @@ namespace Thread::Interface::UI
     inline void DrawTextShadowed(ImGuiMCP::ImDrawList* a_drawList, ImGuiMCP::ImVec2 a_position,
         ImGuiMCP::ImU32 a_color, const char* a_text)
     {
-        ImGuiMCP::ImDrawListManager::AddText(a_drawList, { a_position.x - 1, a_position.y - 1 }, Theme::Color::shadow, a_text, nullptr);
-        ImGuiMCP::ImDrawListManager::AddText(a_drawList, { a_position.x + 1, a_position.y - 1 }, Theme::Color::shadow, a_text, nullptr);
-        ImGuiMCP::ImDrawListManager::AddText(a_drawList, { a_position.x - 1, a_position.y + 1 }, Theme::Color::shadow, a_text, nullptr);
-        ImGuiMCP::ImDrawListManager::AddText(a_drawList, { a_position.x + 1, a_position.y + 1 }, Theme::Color::shadow, a_text, nullptr);
+        ImGuiMCP::ImDrawListManager::AddText(a_drawList, { a_position.x - 1, a_position.y - 1 }, Theme::Color.shadow, a_text, nullptr);
+        ImGuiMCP::ImDrawListManager::AddText(a_drawList, { a_position.x + 1, a_position.y - 1 }, Theme::Color.shadow, a_text, nullptr);
+        ImGuiMCP::ImDrawListManager::AddText(a_drawList, { a_position.x - 1, a_position.y + 1 }, Theme::Color.shadow, a_text, nullptr);
+        ImGuiMCP::ImDrawListManager::AddText(a_drawList, { a_position.x + 1, a_position.y + 1 }, Theme::Color.shadow, a_text, nullptr);
         ImGuiMCP::ImDrawListManager::AddText(a_drawList, a_position, a_color, a_text, nullptr);
     }
 }

--- a/src/Thread/Interface/UI/Theme.h
+++ b/src/Thread/Interface/UI/Theme.h
@@ -11,10 +11,13 @@ namespace Thread::Interface::UI::Theme
         ImGuiMCP::ImU32 textMuted = IM_COL32(136, 128, 120, 255);
         ImGuiMCP::ImU32 accent = IM_COL32(112, 184, 112, 255);
 
-        ImGuiMCP::ImU32 surfacePanel = IM_COL32(20, 20, 22, 245);
-        ImGuiMCP::ImU32 surfaceHovered = IM_COL32(36, 36, 40, 245);
-        ImGuiMCP::ImU32 surfacePressed = IM_COL32(34, 34, 36, 245);
-        ImGuiMCP::ImU32 surfaceActive = IM_COL32(22, 25, 23, 245);
+        ImGuiMCP::ImU32 panelBackground = IM_COL32(0, 0, 0, 182);
+        ImGuiMCP::ImU32 panelBorder = IM_COL32(255, 255, 255, 58);
+
+        ImGuiMCP::ImU32 buttonIdle = IM_COL32(20, 20, 22, 245);
+        ImGuiMCP::ImU32 buttonHovered = IM_COL32(36, 36, 40, 245);
+        ImGuiMCP::ImU32 buttonPressed = IM_COL32(34, 34, 36, 245);
+        ImGuiMCP::ImU32 buttonSelected = IM_COL32(22, 25, 23, 245);
         ImGuiMCP::ImU32 separator = IM_COL32(55, 55, 58, 128);
         ImGuiMCP::ImU32 shadow = IM_COL32(0, 0, 0, 210);
         ImGuiMCP::ImU32 shadowSoft = IM_COL32(0, 0, 0, 90);

--- a/src/Util/AsyncIO.cpp
+++ b/src/Util/AsyncIO.cpp
@@ -1,0 +1,80 @@
+#include "AsyncIO.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <thread>
+
+namespace Util::AsyncIO
+{
+    namespace
+    {
+        using namespace std::chrono_literals;
+
+        class TaskConsumer final
+        {
+          public:
+            ~TaskConsumer()
+            {
+                _worker.request_stop();
+                _condition.notify_all();
+            }
+
+            void Submit(std::move_only_function<void()> a_task)
+            {
+                {
+                    std::lock_guard lock{ _mutex };
+                    _tasks.emplace_back(std::move(a_task));
+                    if (!_running) {
+                        if (_worker.joinable())
+                            _worker.join();
+                        _running = true;
+                        _worker = std::jthread([this](std::stop_token a_stopToken) { Run(a_stopToken); });
+                    }
+                }
+                _condition.notify_one();
+            }
+
+          private:
+            void Run(std::stop_token a_stopToken)
+            {
+                std::unique_lock lock{ _mutex };
+                while (!a_stopToken.stop_requested()) {
+                    if (_tasks.empty() &&
+                        !_condition.wait_for(lock, a_stopToken, 2s, [this]() { return !_tasks.empty(); })) {
+                        _running = false;
+                        return;
+                    }
+                    if (a_stopToken.stop_requested())
+                        break;
+
+                    auto task = std::move(_tasks.front());
+                    _tasks.pop_front();
+                    lock.unlock();
+                    try {
+                        task();
+                    } catch (const std::exception& e) {
+                        logger::error("Async I/O task failed: {}", e.what());
+                    } catch (...) {
+                        logger::error("Async I/O task failed with an unknown exception");
+                    }
+                    lock.lock();
+                }
+                _running = false;
+            }
+
+            std::mutex _mutex;
+            std::condition_variable_any _condition;
+            std::deque<std::move_only_function<void()>> _tasks;
+            bool _running{ false };
+            std::jthread _worker;
+        };
+    }
+
+    void Submit(std::move_only_function<void()> a_task)
+    {
+        static TaskConsumer consumer;
+        consumer.Submit(std::move(a_task));
+    }
+}

--- a/src/Util/AsyncIO.h
+++ b/src/Util/AsyncIO.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <functional>
+
+// Simple cached single thread consumer. Intended to provide cheap async operations
+// without having to manage a platform thread manually. Cached threads are disposed of
+// after 2 seconds of non-operation
+namespace Util::AsyncIO
+{
+    void Submit(std::move_only_function<void()> a_task);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "Thread/Hooks.h"
 #include "Thread/Interface/FurnSelectMenu.h"
 #include "Thread/Interface/SceneHUD.h"
+#include "Thread/Interface/UI/Theme.h"
 #include "Thread/NiNode/Legacy/LegacyNiUpdate.h"
 #include "Thread/NiNode/NiUpdate.h"
 #include "UserData/StripData.h"
@@ -78,6 +79,7 @@ static void SKSEMessageHandler(SKSE::MessagingInterface::Message* message)
             Thread::Interface::FurnSelectMenu::GetSingleton().Register();
         break;
     case SKSE::MessagingInterface::kDataLoaded:
+        Thread::Interface::UI::Theme::Load();
         Settings::Initialize();
         if (!GameForms::LoadData()) {
             logger::critical("Unable to load esp objects");

--- a/xmake-requires.lock
+++ b/xmake-requires.lock
@@ -14,7 +14,7 @@
         ["directxmath 2024.02#f56260b5"] = {
             repo = {
                 branch = "master",
-                commit = "3a3468812c7cea1482d114361c40034c3db07274",
+                commit = "33a3d2592b35c2e02b01b0824a9f017a787ddec1",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "2024.02"
@@ -22,7 +22,7 @@
         ["directxtk 24.2.0#f56260b5"] = {
             repo = {
                 branch = "master",
-                commit = "3a3468812c7cea1482d114361c40034c3db07274",
+                commit = "33a3d2592b35c2e02b01b0824a9f017a787ddec1",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "24.2.0"
@@ -31,9 +31,17 @@
             repo = {
                 branch = "master",
                 commit = "8917c2f7818847fead2be9b3b6f77d90d97323f3",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
+                url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "5.0.1"
+        },
+        ["glaze#f56260b5"] = {
+            repo = {
+                branch = "master",
+                commit = "3a3468812c7cea1482d114361c40034c3db07274",
+                url = "https://github.com/xmake-io/xmake-repo.git"
+            },
+            version = "v7.0.2"
         },
         ["glm#f56260b5"] = {
             repo = {
@@ -59,18 +67,10 @@
             },
             version = "v1.13.1"
         },
-        ["nlohmann_json#f56260b5"] = {
-            repo = {
-                branch = "master",
-                commit = "3a3468812c7cea1482d114361c40034c3db07274",
-                url = "https://github.com/xmake-io/xmake-repo.git"
-            },
-            version = "v3.12.0"
-        },
         ["rapidcsv v8.92#f56260b5"] = {
             repo = {
                 branch = "master",
-                commit = "3a3468812c7cea1482d114361c40034c3db07274",
+                commit = "33a3d2592b35c2e02b01b0824a9f017a787ddec1",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "v8.92"
@@ -86,7 +86,7 @@
         ["spdlog v1.16.0#09c8c173"] = {
             repo = {
                 branch = "master",
-                commit = "3a3468812c7cea1482d114361c40034c3db07274",
+                commit = "33a3d2592b35c2e02b01b0824a9f017a787ddec1",
                 url = "https://github.com/xmake-io/xmake-repo.git"
             },
             version = "v1.16.0"

--- a/xmake.lua
+++ b/xmake.lua
@@ -92,7 +92,7 @@ option_end()
 
 -- Dependencies & Includes
 -- https://github.com/xmake-io/xmake-repo/tree/dev
-add_requires("yaml-cpp", "magic_enum", "nlohmann_json", "simpleini", "glm", "eigen")
+add_requires("yaml-cpp", "magic_enum", "glaze", "simpleini", "glm", "eigen")
 
 -- policies
 set_policy("package.requires_lock", true)
@@ -151,7 +151,7 @@ add_rules("common")
 target(PROJECT_NAME)
     set_enabled(get_config("build_dll"))
     -- Dependencies
-    add_packages("yaml-cpp", "magic_enum", "nlohmann_json", "simpleini", "glm", "eigen")
+    add_packages("yaml-cpp", "magic_enum", "glaze", "simpleini", "glm", "eigen")
 
     -- CommonLibSSE
     add_deps("commonlibsse-ng")


### PR DESCRIPTION
Continuation of #31  

This makes all the colors editable in-game through ImGUI's build-in color editor. Anything added into the color structs will be auto-magically editable thanks to Glaze's reflection (Reason #1344 why you should use Glaze). 

`AsyncIO` is a new consumer utility I added for the sake of future async implementations. It caches a single platform thread, and automatically releases it after a few seconds of idling. Why do this? Largest reason, it serves as a simple race-proof consumer while providing a simple async schedule API. That means multiple saves can't create an IO race, reads can't race against saves, and so on.. 

`loadComplete` was included in `Theme.cpp` PURELY as a "just in case.." guard. It should be virtually impossible for that to contend, but fuck it - it provides a path for lazy loading in the future. 