### PR TITLE
fix: Don't repeatedly set the animation speed

### DIFF
--- a/src/Thread/ThreadAnimation.cpp
+++ b/src/Thread/ThreadAnimation.cpp
@@ -697,6 +697,9 @@ namespace Thread
 
     void Instance::SetAnimationPlaybackSpeed(float playbackSpeed)
     {
+        if (animationPlaybackSpeed == playbackSpeed) {
+            return;
+        }
         animationPlaybackSpeed = playbackSpeed;
         std::vector<std::pair<RE::BSAnimationGraphManagerPtr, std::unique_ptr<RE::BSSpinLockGuard>>> lockedGraphs;
 


### PR DESCRIPTION
The papyrus thread sets the animation speed every 0.5 seconds, even if enjoyment speed change is disabled. 

Performance waste, and this breaks other mods that mutate the animation speed. 