### PR TITLE
fix: Race issue with papyrus scene start

### DIFF
--- a/dist/Source/Scripts/sslThreadModel.psc
+++ b/dist/Source/Scripts/sslThreadModel.psc
@@ -1112,10 +1112,14 @@ State Animating
 	EndEvent
 	Function AnimationStart()
 		_animationSyncCount += 1
-		Log("AnimationStart called " + _animationSyncCount + "/" + (_Positions.Length + 1) + " times")
-		If (_animationSyncCount < (_Positions.Length + 1))
+		int syncCount = _animationSyncCount
+		int syncTarget = _Positions.Length + 1
+		If (syncCount != syncTarget || _animationSyncPending)
+			Log("AnimationStart called " + syncCount + "/" + syncTarget + " times")
 			return
 		EndIf
+		_animationSyncPending = true
+		Log("AnimationStart called " + syncCount + "/" + syncTarget + " times")
 		Log("AnimationStart fully setup, begin animating")
 		If (HasPlayer)
 			If(IsVictim(PlayerRef) && Config.DisablePlayer)


### PR DESCRIPTION
```
Callback A: increments counter to 2
Callback A: enters Log() and pauses
Callback B: increments counter to 3
Callback B: enters Log() and pauses
Callback A: resumes, reads shared counter = 3 then starts stage
Callback B: resumes, reads shared counter = 3 starts stage again
```

Is what was happening sometimes it appears, which led to the scene terminating at times.

Here's the relevant logs from the discord user who experienced this issue (I was not able to reproduce it, however I do recall it happening at least once before):

```
[07/25/2026 - 08:07:31PM] [SexLab] Thread[1] ContinueSetup called with TRUE
[07/25/2026 - 08:07:31PM] [SexLab] Thread[1] PrepareDone() called 1/3 times
[07/25/2026 - 08:07:32PM] [SexLab] Thread[1] PrepareDone() called 2/3 times
[07/25/2026 - 08:07:34PM] [SexLab] Thread[1] PrepareDone() called 3/3 times
[07/25/2026 - 08:07:34PM] [SexLab] Thread[1] ActorAlias[Lauren] State [Paused] Locked Actor: Lauren
[07/25/2026 - 08:07:34PM] [SexLab] Thread[1] Thread validated, playing animation: o5msuxav, Milky Missionary 2
[07/25/2026 - 08:07:34PM] [SexLab] Thread[1] AnimationStarting
[07/25/2026 - 08:07:35PM] [SexLab] Thread[1] AnimationStart called 1/3 times
[07/25/2026 - 08:07:35PM] [SexLab] Thread[1] AnimationStart called 2/3 times
[07/25/2026 - 08:07:35PM] [SexLab] Thread[1] AnimationStart called 3/3 times
[07/25/2026 - 08:07:35PM] [SexLab] Thread[1] AnimationStart fully setup, begin animating <--- FIRST START
[07/25/2026 - 08:07:35PM] [SexLab] Taking control over thread: [sslThreadController <SexLabThread01 (0A062452)>]
[07/25/2026 - 08:07:35PM] Error: No active stage
stack:
	[SexLabThread01 (0A062452)].sslThreadController.GetActiveStage() - "<native>" Line ?
	[SexLabThread01 (0A062452)].sslThreadController.startStage() - "sslThreadModel.psc" Line ?
	[SexLabThread01 (0A062452)].sslThreadController.AnimationStart() - "sslThreadModel.psc" Line ?
	[alias ActorAlias004 on quest SexLabThread01 (0A062452)].sslActorAlias.OnStartPlaying() - "sslActorAlias.psc" Line ?
[07/25/2026 - 08:07:35PM] [SexLab] Thread[1] Starting stage  with history: []
[07/25/2026 - 08:07:35PM] [SexLab] Thread[1] StageStart
[07/25/2026 - 08:07:35PM] [SexLab] Running HookID 1 from thread [sslThreadController <SexLabThread01 (0A062452)>], 0 hooks registered
[07/25/2026 - 08:07:35PM] sc1 (): Sex act quality score: 36
[07/25/2026 - 08:07:35PM] [SexLab] Thread[1] AnimationStart fully setup, begin animating **<--- SECOND START, NOT GOOD!!**
```

