### PR TITLE
refactor: Use percise timers for fixed-length animations to avoid latency

### DIFF
--- a/dist/Source/Scripts/sslThreadModel.psc
+++ b/dist/Source/Scripts/sslThreadModel.psc
@@ -1079,6 +1079,7 @@ int _initialRealignTicks	; Placement is only asserted once per stage; if the fir
 
 bool _QuickResetScenes		; reinits thread without actor/center changes (e.g. to get new playing scenes)
 bool _ForceAdvance		; Force fully auto advance (set by timed stages)
+bool _NativeFixedLengthTimer	; whether the current stage timer is owned by the native frame update
 float _StageTimer			; timer for the current stage
 float _StageDuration		; duration of the current stage
 bool _TimerPaused		; whether timer drain for current stage should be paused
@@ -1250,10 +1251,19 @@ State Animating
 	EndFunction
 
 	Function ReStartTimer()
+		ConfigureStageTimer(true)
+	EndFunction
+
+	Function ConfigureStageTimer(bool abRestartFixedTimer)
 		_ForceAdvance = false
 		_StageDuration = GetTimer()
 		_StageTimer = _StageDuration
-		If (!_ForceAdvance && !AutoAdvance)
+		_NativeFixedLengthTimer = _ForceAdvance
+		If (_NativeFixedLengthTimer)
+			If (abRestartFixedTimer)
+				RestartFixedLengthTimer()
+			EndIf
+		ElseIf (!AutoAdvance)
 			UpdateMenuTimerDisplay(0.0, 0.0)
 		Else
 			UpdateMenuTimerDisplay(_StageDuration, _StageTimer)
@@ -1262,6 +1272,10 @@ State Animating
 	EndFunction
 
 	Function UpdateTimer(float AddSeconds = 0.0)
+		If (_NativeFixedLengthTimer && AdjustFixedLengthTimer(AddSeconds))
+			_ForceAdvance = true
+			return
+		EndIf
 		_StageTimer += AddSeconds
 		_ForceAdvance = true
 		UpdateMenuTimerDisplay(_StageDuration, _StageTimer)
@@ -1269,6 +1283,7 @@ State Animating
 
 	Function PauseTimer(bool abEnable)
 		_TimerPaused = abEnable
+		SetFixedLengthTimerPaused(abEnable)
 	EndFunction
 
 	Function SetTimers(float[] SetTimers)
@@ -1302,6 +1317,18 @@ State Animating
 		return Timers[lastTimerIdx]
 	Endfunction
 	
+	Function AdvanceFromTimer()
+		If !ThreadWaitsForOrgasm()
+			GoToStage(_StageHistory.Length + 1)
+		Else
+			string[] NewSceneStage = FindSimilarSceneStage()
+			ResetScene(NewSceneStage[0])
+			int NewStageNum = SexlabRegistry.GetAllStages(NewSceneStage[0]).Find(NewSceneStage[1])
+			GoToStage(NewStageNum)
+			Log("Skipped scene to " + SexlabRegistry.GetSceneName(NewSceneStage[0]) + " (Stage: " + NewStageNum + ")")
+		EndIf
+	EndFunction
+
 	Event OnUpdate()
 		If (SexLabUtil.IsGamePausedOrFrozen())
 			RegisterForSingleUpdate(ANIMATING_UPDATE_INTERVAL)
@@ -1313,21 +1340,12 @@ State Animating
 				RealignActors()
 			EndIf
 		EndIf
-		If (!_TimerPaused && (AutoAdvance || _ForceAdvance))
+		If (!_NativeFixedLengthTimer && !_TimerPaused && (AutoAdvance || _ForceAdvance))
 			_StageTimer -= ANIMATING_UPDATE_INTERVAL
 			UpdateMenuTimerDisplay(_StageDuration, _StageTimer)
 			If (_StageTimer <= 0)
-				If !ThreadWaitsForOrgasm()
-					GoToStage(_StageHistory.Length + 1)
-					return
-				Else
-					string[] NewSceneStage = FindSimilarSceneStage()
-					ResetScene(NewSceneStage[0])
-					int NewStageNum = SexlabRegistry.GetAllStages(NewSceneStage[0]).Find(NewSceneStage[1])
-					GoToStage(NewStageNum)
-					Log("Skipped scene to " + SexlabRegistry.GetSceneName(NewSceneStage[0]) + " (Stage: " + NewStageNum + ")")
-					return
-				EndIf
+				AdvanceFromTimer()
+				return
 			EndIf
 		EndIf
 		If (_SFXTimer > 0)
@@ -1472,6 +1490,16 @@ State Animating
 		EndWhile
 	EndFunction
 
+	Function OnFixedLengthStageComplete()
+		If (_animationSyncPending)
+			return
+		EndIf
+		If (!ConsumeFixedLengthTimerExpiration())
+			return
+		EndIf
+		AdvanceFromTimer()
+	EndFunction
+
 	Function OnAnimationSynchronized()
 		_animationSyncPending = false
 		String queuedScene = _queuedSceneReset
@@ -1481,13 +1509,16 @@ State Animating
 			return
 		EndIf
 		UpdateOffsetSlidersDisplay()
-		ReStartTimer()
+		ConfigureStageTimer(false)
 		If (!_animationStarted)
 			_animationStarted = true
 			SendThreadEvent("AnimationStart")
 			If (LeadIn)
 				SendThreadEvent("LeadInStart")
 			EndIf
+		EndIf
+		If (ConsumeFixedLengthTimerExpiration())
+			AdvanceFromTimer()
 		EndIf
 	EndFunction
 
@@ -1535,6 +1566,9 @@ EndFunction
 Function ReStartTimer()
 	Log("Cannot re/start timers outside of playing state", "ReStartTimer()")
 EndFunction
+Function ConfigureStageTimer(bool abRestartFixedTimer)
+	Log("Cannot configure timers outside of playing state", "ConfigureStageTimer()")
+EndFunction
 Function UpdateTimer(float AddSeconds = 0.0)
 	Log("Cannot update timers outside of playing state", "UpdateTimer()")
 EndFunction
@@ -1574,6 +1608,14 @@ Function OnNativeActorsPrepared()
 	Log("OnNativeActorsPrepared(), Function called from invalid state: " + GetState())
 EndFunction
 
+Function OnFixedLengthStageComplete()
+	Log("OnFixedLengthStageComplete(), Function called from invalid state: " + GetState())
+EndFunction
+
+Function AdvanceFromTimer()
+	Log("AdvanceFromTimer(), Function called from invalid state: " + GetState())
+EndFunction
+
 Function OnAnimationSynchronized()
 	Log("OnAnimationSynchronized(), Function called from invalid state: " + GetState())
 EndFunction
@@ -1585,6 +1627,10 @@ bool Function SetActiveScene(String asScene) native
 bool Function ReassignCenter(ObjectReference CenterOn) native
 bool Function SetNextPermutation(Actor akActor) native
 Function UpdatePlacement(Actor akActor) native
+bool Function RestartFixedLengthTimer() native
+bool Function AdjustFixedLengthTimer(float afDelta) native
+Function SetFixedLengthTimerPaused(bool abPaused) native
+bool Function ConsumeFixedLengthTimerExpiration() native
 ; Physics/SFX Related
 bool Function IsCollisionRegistered() native
 Function UnregisterCollision() native
@@ -2218,6 +2264,7 @@ Function Initialize()
 	_Hooks = Utility.CreateStringArray(0)
 	_AnimationSpeedBase = 1.0
 	_TimerPaused = false
+	_NativeFixedLengthTimer = false
 	_QuickResetScenes = false
 	_animationStarted = false
 	_animationSyncPending = false

--- a/src/Papyrus/sslThreadModel.cpp
+++ b/src/Papyrus/sslThreadModel.cpp
@@ -793,6 +793,30 @@ namespace Papyrus::ThreadModel
         instance->SetAnimationPlaybackSpeed(a_playbackSpeed);
     }
 
+    bool RestartFixedLengthTimer(QUESTARGS)
+    {
+        GET_INSTANCE(false);
+        return instance->RestartFixedLengthTimer();
+    }
+
+    bool AdjustFixedLengthTimer(QUESTARGS, float a_delta)
+    {
+        GET_INSTANCE(false);
+        return instance->AdjustFixedLengthTimer(a_delta);
+    }
+
+    void SetFixedLengthTimerPaused(QUESTARGS, bool a_paused)
+    {
+        GET_INSTANCE();
+        instance->SetFixedLengthTimerPaused(a_paused);
+    }
+
+    bool ConsumeFixedLengthTimerExpiration(QUESTARGS)
+    {
+        GET_INSTANCE(false);
+        return instance->ConsumeFixedLengthTimerExpiration();
+    }
+
     void AddExperience(QUESTARGS, std::vector<RE::Actor*> a_positions, RE::BSFixedString a_scene, std::vector<RE::BSFixedString> a_playedstages)
     {
         const auto scene = Registry::Library::GetSingleton()->GetSceneById(a_scene);

--- a/src/Papyrus/sslThreadModel.h
+++ b/src/Papyrus/sslThreadModel.h
@@ -77,6 +77,10 @@ namespace Papyrus::ThreadModel
     float GetActionVelocity(QUESTARGS, RE::Actor* a_position, RE::Actor* a_partner, int a_type);
 
     void SetAnimationPlaybackSpeed(QUESTARGS, float a_playbackSpeed);
+    bool RestartFixedLengthTimer(QUESTARGS);
+    bool AdjustFixedLengthTimer(QUESTARGS, float a_delta);
+    void SetFixedLengthTimerPaused(QUESTARGS, bool a_paused);
+    bool ConsumeFixedLengthTimerExpiration(QUESTARGS);
 
     void AddExperience(QUESTARGS, std::vector<RE::Actor*> a_positions, RE::BSFixedString a_scene, std::vector<RE::BSFixedString> a_playedstages);
     void UpdateStatistics(QUESTARGS, RE::Actor* a_actor, std::vector<RE::Actor*> a_positions, RE::BSFixedString a_scene, std::vector<RE::BSFixedString> a_playedstages, float a_time);
@@ -124,6 +128,10 @@ namespace Papyrus::ThreadModel
         REGISTERFUNC(GetActionVelocity, "sslThreadModel", true);
 
         REGISTERFUNC(SetAnimationPlaybackSpeed, "sslThreadModel", false);
+        REGISTERFUNC(RestartFixedLengthTimer, "sslThreadModel", false);
+        REGISTERFUNC(AdjustFixedLengthTimer, "sslThreadModel", false);
+        REGISTERFUNC(SetFixedLengthTimerPaused, "sslThreadModel", false);
+        REGISTERFUNC(ConsumeFixedLengthTimerExpiration, "sslThreadModel", false);
 
         REGISTERFUNC(AddExperience, "sslThreadModel", true);
         REGISTERFUNC(UpdateStatistics, "sslThreadModel", true);

--- a/src/Thread/Thread.cpp
+++ b/src/Thread/Thread.cpp
@@ -100,6 +100,7 @@ namespace Thread
         } else if (niInstance == nullptr) {
             niInstance = NiNode::NiUpdate::Register(linkedQst->formID, *activeAssignment, activeScene);
         }
+        fixedLengthTimer.state = FixedLengthTimer::State::Stopped;
         activeStage = a_nextStage;
         ReleaseAnimations();
         pendingAnimations.clear();
@@ -137,6 +138,7 @@ namespace Thread
             logger::warn("Scene {} has no valid assignments.", a_scene->id);
             return false;
         }
+        CancelFixedLengthTimer();
         assignments = newAssignments;
         activeScene = a_scene;
         ReleaseAnimations();

--- a/src/Thread/Thread.h
+++ b/src/Thread/Thread.h
@@ -100,6 +100,10 @@ namespace Thread
         void SetCenterRefSelected(size_t a_index);
 
         void SetAnimationPlaybackSpeed(float playbackSpeed);
+        bool RestartFixedLengthTimer();
+        bool AdjustFixedLengthTimer(float a_delta);
+        void SetFixedLengthTimerPaused(bool a_paused);
+        bool ConsumeFixedLengthTimerExpiration();
         void OffsetAdjustSet(uint32_t actorFormId, Registry::CoordinateType axis, float value);
         void OffsetAdjustReset(bool hasFurn);
 
@@ -161,6 +165,23 @@ namespace Thread
             bool getUpEndQueued{ false };
         };
 
+        // Used by animation stages that have percise animation play time, to avoid the Papyrus 0.5
+        // second poll delay
+        struct FixedLengthTimer
+        {
+            enum class State : uint8_t
+            {
+                Stopped,
+                Running,
+                Expired,
+            };
+
+            float duration{ 0.0f };
+            float remaining{ 0.0f };
+            State state{ State::Stopped };
+            bool paused{ false };
+        };
+
         RE::TESQuest* linkedQst;
         std::shared_ptr<NiNode::NiInstance> niInstance{ nullptr };
         std::shared_ptr<LegacyNiNode::NiInstance> niInstanceLegacy{ nullptr };
@@ -182,6 +203,7 @@ namespace Thread
         bool playerSheatheActionSubmitted{ false };
         bool playerSheathePending{ false };
         float animationPlaybackSpeed{ 1.0f };
+        FixedLengthTimer fixedLengthTimer{};
 
         // used during center selection through menu
         RE::TESQuest* pendingQst{ nullptr };
@@ -209,6 +231,9 @@ namespace Thread
         void TryStartAnimations();
         bool HoldAnimation(PendingAnimation& a_pending);
         void ReleaseAnimations();
+        bool StartFixedLengthTimer();
+        void CancelFixedLengthTimer();
+        void UpdateFixedLengthTimer(float a_delta);
         void UpdatePendingAnimations(float a_delta);
         void UpdatePendingRecoveries(float a_delta);
         void ReassertPlacement(size_t a_position, bool a_force);

--- a/src/Thread/ThreadAnimation.cpp
+++ b/src/Thread/ThreadAnimation.cpp
@@ -148,6 +148,7 @@ namespace Thread
                 if (instance->linkedQst != a_linkedQst) {
                     continue;
                 }
+                instance->CancelFixedLengthTimer();
                 instance->ReleaseAnimations();
                 if (!instance->pendingAnimations.empty()) {
                     logger::info("Cancelled {} pending animation synchronization(s).", instance->pendingAnimations.size());
@@ -302,11 +303,82 @@ namespace Thread
         return false;
     }
 
+    bool Instance::StartFixedLengthTimer()
+    {
+        fixedLengthTimer.state = FixedLengthTimer::State::Stopped;
+        if (!activeStage || activeStage->fixedlength == 0.0f) {
+            return false;
+        }
+        const auto duration = activeStage->fixedlength / 1000.0f;
+        fixedLengthTimer.duration = duration;
+        fixedLengthTimer.remaining = duration;
+        fixedLengthTimer.state = FixedLengthTimer::State::Running;
+        UpdateMenuTimerDisplay(duration, duration);
+        return true;
+    }
+
+    void Instance::CancelFixedLengthTimer()
+    {
+        fixedLengthTimer.state = FixedLengthTimer::State::Stopped;
+    }
+
+    bool Instance::RestartFixedLengthTimer()
+    {
+        return StartFixedLengthTimer();
+    }
+
+    bool Instance::AdjustFixedLengthTimer(float a_delta)
+    {
+        if (fixedLengthTimer.state == FixedLengthTimer::State::Stopped) {
+            return false;
+        }
+        fixedLengthTimer.remaining += a_delta;
+        fixedLengthTimer.state = FixedLengthTimer::State::Running;
+        UpdateMenuTimerDisplay(fixedLengthTimer.duration, std::max(0.0f, fixedLengthTimer.remaining));
+        return true;
+    }
+
+    void Instance::SetFixedLengthTimerPaused(bool a_paused)
+    {
+        fixedLengthTimer.paused = a_paused;
+    }
+
+    bool Instance::ConsumeFixedLengthTimerExpiration()
+    {
+        if (fixedLengthTimer.state != FixedLengthTimer::State::Expired) {
+            return false;
+        }
+        fixedLengthTimer.state = FixedLengthTimer::State::Stopped;
+        return true;
+    }
+
+    void Instance::UpdateFixedLengthTimer(float a_delta)
+    {
+        if (fixedLengthTimer.state != FixedLengthTimer::State::Running || fixedLengthTimer.paused || a_delta <= 0.0f) {
+            return;
+        }
+        fixedLengthTimer.remaining = std::max(0.0f, fixedLengthTimer.remaining - a_delta);
+        const auto expired = fixedLengthTimer.remaining <= 0.0f;
+        if (expired) {
+            fixedLengthTimer.state = FixedLengthTimer::State::Expired;
+        }
+        UpdateMenuTimerDisplay(fixedLengthTimer.duration, fixedLengthTimer.remaining);
+        if (!expired) {
+            return;
+        }
+        const auto scriptObject = Script::GetScriptObject(linkedQst, "sslThreadModel");
+        Script::CallbackPtr callbackPtr{};
+        if (!scriptObject || !Script::DispatchMethodCall(scriptObject, "OnFixedLengthStageComplete", callbackPtr)) {
+            logger::error("Failed to notify Papyrus of fixed-length timer completion for thread {:X}.", linkedQst->GetFormID());
+        }
+    }
+
     void Instance::UpdateAnimations(float a_delta)
     {
         const auto timeoutDelta = Util::IsGamePausedOrFrozen() ? 0.0f : a_delta;
         std::shared_lock lock{ _mInstances };
         for (auto&& instance : instances) {
+            instance->UpdateFixedLengthTimer(timeoutDelta);
             instance->UpdatePendingAnimations(timeoutDelta);
         }
     }
@@ -687,6 +759,7 @@ namespace Thread
             ReleaseAnimations();
             logger::info("Released {} synchronized animation clips.", pendingAnimations.size());
             pendingAnimations.clear();
+            StartFixedLengthTimer();
             const auto scriptObject = Script::GetScriptObject(linkedQst, "sslThreadModel");
             Script::CallbackPtr callbackPtr{};
             if (!scriptObject || !Script::DispatchMethodCall(scriptObject, "OnAnimationSynchronized", callbackPtr)) {


### PR DESCRIPTION
Papyrus polls every ~0.5 seconds for the fixed length timers, so that plus the additional papyrus latency was leading to obvious pauses in animations. This implementation binds the timer to the game time for near-perfect synchronization. 

This is more of a patch than a proper implementation, since a proper implementation would be refactoring a large percentage of the Papyrus code base to give C++ control over all timers. 