### PR TITLE
fix: Avoid engine dialogue cleanup race

### DIFF
--- a/dist/Source/Scripts/sslThreadModel.psc
+++ b/dist/Source/Scripts/sslThreadModel.psc
@@ -886,11 +886,21 @@ EndState
 ; An immediate state to disallow setting additional data while aliases process setup
 State Making_M
 	Event OnBeginState()
+		If (!BeginPlayerDialogueWait())
+			return
+		EndIf
 		If (!BeginActorRecovery())
 			return
 		EndIf
 		BeginAliasPreparation()
 	EndEvent
+
+	Function OnPlayerDialogueComplete()
+		If (!BeginActorRecovery())
+			return
+		EndIf
+		BeginAliasPreparation()
+	EndFunction
 
 	Function OnNativeActorRecoveryComplete(bool abSucceeded)
 		If (!abSucceeded)
@@ -1055,6 +1065,7 @@ EndFunction
 
 Function CreateInstance(Actor[] akSubmissives, String[] asPrimaryScenes, String[] asLeadInScenes, String[] asCustomScenes, int aiFurnitureStatus) native
 bool Function BeginActorRecovery() native
+bool Function BeginPlayerDialogueWait() native
 bool Function BeginPlayerSheatheWait() native
 String[] Function GetLeadInScenes() native
 String[] Function GetPrimaryScenes() native
@@ -1855,6 +1866,9 @@ Function PrepareDone()
 EndFunction
 Function OnNativeActorRecoveryComplete(bool abSucceeded)
 	Log("OnNativeActorRecoveryComplete(), Function called from invalid state: " + GetState())
+EndFunction
+Function OnPlayerDialogueComplete()
+	Log("OnPlayerDialogueComplete(), Function called from invalid state: " + GetState())
 EndFunction
 Function BeginAliasPreparation()
 	Log("BeginAliasPreparation(), Function called from invalid state: " + GetState())

--- a/src/Papyrus/sslThreadModel.cpp
+++ b/src/Papyrus/sslThreadModel.cpp
@@ -308,6 +308,12 @@ namespace Papyrus::ThreadModel
         return instance->BeginActorRecovery();
     }
 
+    bool BeginPlayerDialogueWait(QUESTARGS)
+    {
+        GET_INSTANCE(false);
+        return instance->BeginPlayerDialogueWait();
+    }
+
     bool BeginPlayerSheatheWait(QUESTARGS)
     {
         GET_INSTANCE(false);

--- a/src/Papyrus/sslThreadModel.h
+++ b/src/Papyrus/sslThreadModel.h
@@ -55,6 +55,7 @@ namespace Papyrus::ThreadModel
     void DestroyInstance(RE::TESQuest* a_qst, bool a_preservePreparedActors);
     void CancelPendingAnimations(RE::TESQuest* a_qst);
     bool BeginActorRecovery(QUESTARGS);
+    bool BeginPlayerDialogueWait(QUESTARGS);
     bool BeginPlayerSheatheWait(QUESTARGS);
     std::vector<RE::BSFixedString> GetLeadInScenes(QUESTARGS);
     std::vector<RE::BSFixedString> GetPrimaryScenes(QUESTARGS);
@@ -109,6 +110,7 @@ namespace Papyrus::ThreadModel
         REGISTERFUNC(DestroyInstance, "sslThreadModel", true);
         REGISTERFUNC(CancelPendingAnimations, "sslThreadModel", true);
         REGISTERFUNC(BeginActorRecovery, "sslThreadModel", false);
+        REGISTERFUNC(BeginPlayerDialogueWait, "sslThreadModel", false);
         REGISTERFUNC(BeginPlayerSheatheWait, "sslThreadModel", false);
         REGISTERFUNC(GetLeadInScenes, "sslThreadModel", true);
         REGISTERFUNC(GetPrimaryScenes, "sslThreadModel", true);

--- a/src/Thread/Thread.h
+++ b/src/Thread/Thread.h
@@ -81,6 +81,7 @@ namespace Thread
 
         void AdvanceScene(const Registry::Stage* a_nextStage);
         bool BeginActorRecovery();
+        bool BeginPlayerDialogueWait();
         bool BeginPlayerSheatheWait();
         void RealignActors();
         bool SetActiveScene(const Registry::Scene* a_scene);
@@ -203,6 +204,7 @@ namespace Thread
         RE::WEAPON_STATE playerSheathePreviousState{ RE::WEAPON_STATE::kSheathed };
         bool actorPreparationApplied{ false };
         bool actorRecoveryPreparationBarrier{ false };
+        bool playerDialoguePending{ false };
         bool playerSheatheActionSubmitted{ false };
         bool playerSheathePending{ false };
         float animationPlaybackSpeed{ 1.0f };

--- a/src/Thread/ThreadAnimation.cpp
+++ b/src/Thread/ThreadAnimation.cpp
@@ -32,6 +32,12 @@ namespace Thread
         std::mutex actorPreparationLock;
         std::unordered_map<RE::FormID, ActorPreparation> actorPreparations;
 
+        bool IsPlayerDialogueActive()
+        {
+            const auto ui = RE::UI::GetSingleton();
+            return ui && ui->IsMenuOpen(RE::DialogueMenu::MENU_NAME);
+        }
+
         bool PrepareActorForAnimation(RE::TESQuest* a_owner, RE::Actor* a_actor, bool a_human)
         {
             std::scoped_lock lock{ actorPreparationLock };
@@ -53,15 +59,6 @@ namespace Thread
             a_actor->AddToFaction(const_cast<RE::TESFaction*>(GameForms::AnimatingFaction), 1);
             a_actor->EvaluatePackage();
             if (a_actor->IsPlayerRef()) {
-                if (const auto ui = RE::UI::GetSingleton(); ui) {
-                    const auto interfaceStrings = RE::InterfaceStrings::GetSingleton();
-                    if (interfaceStrings && ui->IsMenuOpen(interfaceStrings->dialogueMenu)) {
-                        if (auto view = ui->GetMovieView(interfaceStrings->dialogueMenu)) {
-                            RE::GFxValue argument{ interfaceStrings->dialogueMenu };
-                            view->InvokeNoReturn("_global.skse.CloseMenu", &argument, 1);
-                        }
-                    }
-                }
                 a_actor->AsActorState()->actorState1.lifeState = RE::ACTOR_LIFE_STATE::kAlive;
             } else {
                 if (inserted) {
@@ -156,6 +153,7 @@ namespace Thread
                 }
                 instance->pendingRecoveries.clear();
                 instance->actorRecoveryPreparationBarrier = false;
+                instance->playerDialoguePending = false;
                 instance->playerSheathePending = false;
                 instance->playerSheatheElapsed = 0.0f;
                 instance->playerSheathePreviousState = RE::WEAPON_STATE::kSheathed;
@@ -172,6 +170,22 @@ namespace Thread
     bool Instance::BeginActorRecovery()
     {
         return !QueueActorRecoveries(true);
+    }
+
+    // Player dialogue MUST be waited on. We can race with the engine's dialogue closure handler which
+    // leads to the player permanently being stuck since the dialogue handler fails to cleanup properly
+    bool Instance::BeginPlayerDialogueWait()
+    {
+        if (playerDialoguePending) {
+            return false;
+        }
+        const auto player = RE::PlayerCharacter::GetSingleton();
+        if (!player || !GetPosition(player) || !IsPlayerDialogueActive()) {
+            return true;
+        }
+        playerDialoguePending = true;
+        logger::info("Waiting for player dialogue to finish before preparing actors.");
+        return false;
     }
 
     bool Instance::QueueActorRecoveries(bool a_preparationBarrier)
@@ -648,6 +662,21 @@ namespace Thread
         constexpr float minimumClipWeight = 0.01f;
         constexpr float minimumTimeChange = 0.0001f;
 
+        if (playerDialoguePending) {
+            if (IsPlayerDialogueActive()) {
+                return;
+            }
+            playerDialoguePending = false;
+            logger::info("Player dialogue finished; continuing actor preparation.");
+            const auto scriptObject = Script::GetScriptObject(linkedQst, "sslThreadModel");
+            Script::CallbackPtr callbackPtr{};
+            if (!scriptObject || !Script::DispatchMethodCall(scriptObject, "OnPlayerDialogueComplete", callbackPtr)) {
+                logger::error("Failed to notify Papyrus of player dialogue completion for thread {:X}.", linkedQst->GetFormID());
+            }
+            return;
+        }
+
+        const auto player = RE::PlayerCharacter::GetSingleton();
         if (!pendingRecoveries.empty()) {
             UpdatePendingRecoveries(a_delta);
             return;
@@ -655,7 +684,6 @@ namespace Thread
 
         if (playerSheathePending) {
             playerSheatheElapsed += a_delta;
-            const auto player = RE::PlayerCharacter::GetSingleton();
             const auto weaponState = player ? player->AsActorState()->GetWeaponState() : RE::WEAPON_STATE::kSheathed;
             const bool sheathed = player && weaponState == RE::WEAPON_STATE::kSheathed;
             const bool timedOut = playerSheatheElapsed >= playerSheatheTimeout;


### PR DESCRIPTION
Since we've sped up the animation start sequence, we've left a small gap where if a player initiated sex through dialogue and they wait the entire dialogue play time (No skipping dialogue), there's a high chance we'll race with the engine's dialogue context pop and control handling which permanently locks the player in place. 

This is the cleanest fix I could think of. Alternative is manually popping contexts/etc, but that's just asking for trouble. Could also just wait ~500ms, but that's lame. I don't got time for that? 