### PR TITLE
feat (UI): Cleanup, and improve the offset menu

### DIFF
--- a/src/Thread/Interface/Elements/ElementCtrlPanel.cpp
+++ b/src/Thread/Interface/Elements/ElementCtrlPanel.cpp
@@ -79,7 +79,8 @@ namespace Thread::Interface
                     ImGuiMCP::SameLine(fieldX);
                     ImGuiMCP::SetNextItemWidth(fieldWidth);
                     const auto thousandths = std::llround(std::abs(a_field) * 1000.0f);
-                    const char* format = thousandths % 100 == 0 ? "%.1f" : thousandths % 10 == 0 ? "%.2f" : "%.3f";
+                    const char* format = thousandths % 100 == 0 ? "%.1f" : thousandths % 10 == 0 ? "%.2f" :
+                                                                                                   "%.3f";
                     ImGuiMCP::InputFloat("##value", &a_field, 0.1f, 0.1f, format);
                 } else if constexpr (glz::reflectable<Field>) {
                     if (ImGuiMCP::CollapsingHeader(fieldName.data(), ImGuiMCP::ImGuiTreeNodeFlags_DefaultOpen))
@@ -275,8 +276,7 @@ namespace Thread::Interface
                 style->WindowPadding.x * 2.0f + style->ScrollbarSize,
             editorMaxWidth));
 
-        ImGuiMCP::SetNextWindowPos(ImGuiMCP::ImVec2{ editorRight, io->DisplaySize.y * 0.5f },
-            ImGuiMCP::ImGuiCond_Always, ImGuiMCP::ImVec2{ 1.0f, 0.5f });
+        ImGuiMCP::SetNextWindowPos({ editorRight, io->DisplaySize.y * 0.5f }, ImGuiMCP::ImGuiCond_Appearing, { 1.0f, 0.5f });
         ImGuiMCP::SetNextWindowSizeConstraints(
             ImGuiMCP::ImVec2{ editorWidth, editorMinHeight }, ImGuiMCP::ImVec2{ editorWidth, editorMaxHeight });
 

--- a/src/Thread/Interface/Elements/OffsetAdjustPanel.cpp
+++ b/src/Thread/Interface/Elements/OffsetAdjustPanel.cpp
@@ -1,496 +1,378 @@
 #include "OffsetAdjustPanel.h"
 
+#include <numbers>
+
 namespace Thread::Interface
 {
     using UI::SetWindowFontSize;
 
+    namespace
+    {
+        constexpr float kTargetPickerWidth = 200.0f;
+        constexpr float kAdjustmentPanelWidth = 300.0f;
+        constexpr float kTargetRowHeight = 28.0f;
+        constexpr float kTrackHitExtension = 10.0f;
+        constexpr float kTrackValueWidth = 40.0f;
+        constexpr float kTrackLabelWidth = 20.0f;
+        constexpr float kTrackHeight = 4.0f;
+        constexpr float kTrackNeedleWidth = 3.0f;
+        constexpr float kTrackNeedleExtension = 5.0f;
+        constexpr float kTrackNeedleRounding = 1.5f;
+        constexpr float kTrackCenterTickExtension = 2.0f;
+        constexpr float kDragDistanceUnits = 300.0f;
+        constexpr float kDegreesPerRadian = 180.0f / std::numbers::pi_v<float>;
+        constexpr auto kPanelWindowFlags =
+            ImGuiMCP::ImGuiWindowFlags_NoTitleBar | ImGuiMCP::ImGuiWindowFlags_NoResize |
+            ImGuiMCP::ImGuiWindowFlags_NoMove | ImGuiMCP::ImGuiWindowFlags_NoScrollbar |
+            ImGuiMCP::ImGuiWindowFlags_NoCollapse | ImGuiMCP::ImGuiWindowFlags_AlwaysAutoResize;
+
+        void DrawPanelHeader(UI::Scale& a_scale, const char* a_title)
+        {
+            SetWindowFontSize(a_scale.TextPx(UI::Theme::FontSize.sectionHeader));
+            const float titleWidth = ImGuiMCP::CalcTextSize(a_title).x;
+            ImGuiMCP::SetCursorPosX(ImGuiMCP::GetCursorPosX() + std::max((ImGuiMCP::GetContentRegionAvail().x - titleWidth) * 0.5f, 0.0f));
+            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textPrimary), "%s", a_title);
+            ImGuiMCP::Dummy({ 0.0f, a_scale.Px(UI::Theme::Spacing.xs) });
+            ImGuiMCP::Separator();
+        }
+    }
+
     void OffsetAdjustPanel::Open(SceneHUD& a_hud)
     {
-        auto* inst = a_hud.GetThreadInstance();
-        if (!inst)
+        Close();
+        auto* instance = a_hud.GetThreadInstance();
+        if (!instance)
             return;
-        _axes.clear();
-        auto* ctr = inst->GetCenterRef();
 
-        _hasFurniture = ctr && !ctr->IsPlayerRef();
-        _adjustStageOnly = inst->GetThreadProperty<bool>("VarUI_AdjustStage");
-        _selectedId.reset();
-        _pickerOpen = false;
-        _panelOpen = false;
-        _draggingAxis = -1;
-        _draggingId = 0;
+        const auto* center = instance->GetCenterRef();
+        _hasFurnitureCenter = center && !center->IsPlayerRef();
+        _adjustStageOnly = instance->GetThreadProperty<bool>("VarUI_AdjustStage");
+        RefreshTargets(a_hud);
 
-        RefreshSlots(a_hud);
-
-        if (_items.size() == 1) {
-            OnActorSelected(a_hud, _items.front());
-        } else if (!_items.empty()) {
-            _pickerOpen = true;
-        }
+        if (_targets.size() == 1)
+            OnTargetSelected(a_hud, 0);
     }
 
     void OffsetAdjustPanel::Close()
     {
-        _axes.clear();
-        _items.clear();
-        _selectedId.reset();
-        _pickerOpen = false;
-        _panelOpen = false;
-        _draggingAxis = -1;
-        _draggingId = 0;
+        _targets.clear();
+        _axes = {};
+        _selectedTarget.reset();
+        _draggingAxis.reset();
+        _hasFurnitureCenter = false;
+        _adjustStageOnly = false;
     }
 
-    void OffsetAdjustPanel::RefreshSlots(SceneHUD& a_hud)
+    void OffsetAdjustPanel::RefreshTargets(SceneHUD& a_hud)
     {
-        _items.clear();
-        auto* inst = a_hud.GetThreadInstance();
-        if (!inst)
+        _targets.clear();
+        auto* instance = a_hud.GetThreadInstance();
+        if (!instance)
             return;
 
-        if (_hasFurniture) {
-            ActorItem fi;
-            fi.actor = nullptr;
-            fi.formId = 0;
-            fi.label = "Center";
-            fi.isScene = true;
-            _items.push_back(fi);
-        }
+        if (_hasFurnitureCenter)
+            _targets.push_back({ nullptr, 0, 0, "Center", true });
 
-        const auto actors = inst->GetActors();
-        for (size_t i = 0; i < actors.size(); ++i) {
-            auto* a = actors[i];
-            if (!a)
+        const auto actors = instance->GetActors();
+        for (std::size_t positionIndex = 0; positionIndex < actors.size(); ++positionIndex) {
+            auto* actor = actors[positionIndex];
+            if (!actor)
                 continue;
-            ActorItem item;
-            item.actor = a;
-            item.formId = a->GetFormID();
-            item.posIdx = i;
-            item.label = a->GetDisplayFullName();
-            item.isScene = false;
-            _items.push_back(item);
+            _targets.push_back({ actor, actor->GetFormID(), positionIndex, actor->GetDisplayFullName(), false });
         }
 
-        std::ranges::sort(_items, [](const ActorItem& a, const ActorItem& b) {
-            if (a.isScene != b.isScene)
-                return a.isScene;  // sort center/player first
-            if (!a.actor || !b.actor)
-                return !a.actor;
-            if (a.actor->IsPlayerRef() != b.actor->IsPlayerRef())
-                return a.actor->IsPlayerRef();
-            return a.label < b.label;
+        std::ranges::sort(_targets, [](const TargetItem& a_left, const TargetItem& a_right) {
+            if (a_left.isCenter != a_right.isCenter)
+                return a_left.isCenter;
+            if (!a_left.actor || !a_right.actor)
+                return !a_left.actor && a_right.actor;
+            if (a_left.actor->IsPlayerRef() != a_right.actor->IsPlayerRef())
+                return a_left.actor->IsPlayerRef();
+            return a_left.label < a_right.label;
         });
     }
 
-    // ── RefreshValues ────────────────────────────────────────────────────────
-
-    void OffsetAdjustPanel::RefreshValues(SceneHUD& a_hud, uint32_t actorId)
+    void OffsetAdjustPanel::RefreshValues(SceneHUD& a_hud)
     {
-        auto* inst = a_hud.GetThreadInstance();
-        if (!inst)
-            return;
-        auto* sc = inst->GetActiveScene();
-        auto* st = inst->GetActiveStage();
-        if (!sc || !st)
+        if (!_selectedTarget)
             return;
 
-        std::array<float, 4> raw{};
-        if (actorId == 0) {
-            const auto v = sc->furnitureOffset.GetOffset().AsVector();
-            std::copy_n(v.begin(), 4, raw.begin());
-        } else {
-            for (const auto& item : _items) {
-                if (item.formId == actorId) {
-                    const auto v = st->positions[item.posIdx].offset.GetOffset().AsVector();
-                    std::copy_n(v.begin(), 4, raw.begin());
-                    break;
-                }
-            }
+        auto* instance = a_hud.GetThreadInstance();
+        if (!instance)
+            return;
+        const auto* scene = instance->GetActiveScene();
+        const auto* stage = instance->GetActiveStage();
+        if (!scene || !stage)
+            return;
+
+        const auto& target = _targets[*_selectedTarget];
+        const Registry::Coordinate* offset = nullptr;
+        if (target.isCenter) {
+            offset = &scene->furnitureOffset.GetOffset();
+        } else if (target.positionIndex < stage->positions.size()) {
+            offset = &stage->positions[target.positionIndex].offset.GetOffset();
         }
+        if (!offset)
+            return;
 
-        auto& axes = _axes[actorId];
-        for (int i = 0; i < 4; ++i) {
-            const float val = (i == 3) ? raw[i] * kRadToDeg : raw[i];
-            if (!axes[i].hasBaseline) {
-                axes[i].baseline = val;
-                axes[i].hasBaseline = true;
+        const std::array rawValues{ offset->location.x, offset->location.y, offset->location.z, offset->rotation };
+        for (std::size_t axisIndex = 0; axisIndex < kAxisDefinitions.size(); ++axisIndex) {
+            auto& state = _axes[axisIndex];
+            const float value = kAxisDefinitions[axisIndex].coordinate == Registry::CoordinateType::R ?
+                                    rawValues[axisIndex] * kDegreesPerRadian :
+                                    rawValues[axisIndex];
+            if (!state.hasBaseline) {
+                state.baseline = value;
+                state.hasBaseline = true;
             }
-            // Don't overwrite value while user is actively dragging this axis — that would fight the drag.
-            if (_draggingAxis == i && _draggingId == actorId)
-                continue;
-            axes[i].value = val;
+            if (_draggingAxis != axisIndex)
+                state.value = value;
         }
     }
 
     void OffsetAdjustPanel::RefreshStageOffsets(SceneHUD& a_hud)
     {
-        if (!_selectedId)
-            return;
-        RefreshValues(a_hud, *_selectedId);
+        RefreshValues(a_hud);
     }
 
-    // ── Handlers ──────────────────────────────────────────────────────────────
-
-    void OffsetAdjustPanel::OnActorSelected(SceneHUD& a_hud, const ActorItem& item)
+    void OffsetAdjustPanel::OnTargetSelected(SceneHUD& a_hud, std::size_t a_targetIndex)
     {
-        _selectedId = item.formId;
-        _pickerOpen = false;
-        _panelOpen = true;
-        if (!_axes.contains(item.formId) || !_axes[item.formId][0].hasBaseline)
-            RefreshValues(a_hud, item.formId);
+        _selectedTarget = a_targetIndex;
+        _axes = {};
+        _draggingAxis.reset();
+        RefreshValues(a_hud);
     }
 
-    void OffsetAdjustPanel::OnSetOffset(SceneHUD& a_hud, Registry::CoordinateType axis, uint32_t actorId, float value)
+    void OffsetAdjustPanel::OnSetOffset(SceneHUD& a_hud, Registry::CoordinateType a_axis, std::uint32_t a_targetId, float a_value)
     {
-        auto* inst = a_hud.GetThreadInstance();
-        if (inst)
-            inst->OffsetAdjustSet(actorId, axis, value);
+        if (auto* instance = a_hud.GetThreadInstance())
+            instance->OffsetAdjustSet(a_targetId, a_axis, a_value);
     }
 
     void OffsetAdjustPanel::OnResetOffsets(SceneHUD& a_hud)
     {
-        auto* inst = a_hud.GetThreadInstance();
-        if (!inst || !_selectedId)
+        auto* instance = a_hud.GetThreadInstance();
+        if (!instance || !_selectedTarget)
             return;
-        inst->OffsetAdjustReset(_hasFurniture);
-        _axes.clear();
-        RefreshValues(a_hud, *_selectedId);
+        instance->OffsetAdjustReset(_hasFurnitureCenter);
+        _axes = {};
+        _draggingAxis.reset();
+        RefreshValues(a_hud);
     }
 
-    void OffsetAdjustPanel::OnSetAdjustStageOnly(SceneHUD& a_hud, bool state)
+    void OffsetAdjustPanel::OnSetAdjustStageOnly(SceneHUD& a_hud, bool a_state)
     {
-        _adjustStageOnly = state;
-        auto* inst = a_hud.GetThreadInstance();
-        if (inst)
-            inst->SetThreadProperty<bool>("VarUI_AdjustStage", state);
+        _adjustStageOnly = a_state;
+        if (auto* instance = a_hud.GetThreadInstance())
+            instance->SetThreadProperty<bool>("VarUI_AdjustStage", a_state);
     }
 
-    // ── The offset track widget ───────────────────────────────────────────────
-    bool OffsetAdjustPanel::OffsetTrack(UI::Scale& a_scale, const char* axisLabel, AxisState& state, float range, bool& draggingOut)
+    bool OffsetAdjustPanel::OffsetTrack(UI::Scale& a_scale, const AxisDefinition& a_axis, AxisState& a_state, bool& a_draggingOut)
     {
         bool changed = false;
-        draggingOut = false;
+        a_draggingOut = false;
 
-        const float rowPadH = a_scale.Px(12.0f);
-        const float trackH = a_scale.Px(4.0f);   // track thickness
-        const float needleW = a_scale.Px(3.0f);  // needle thickness
-        const float hitExt = a_scale.Px(10.0f);  // extends clickable/draggable area above and below visible track
-        const float valW = a_scale.Px(40.0f);    // width of the numeric value field
-        const float labelW = a_scale.Px(20.0f);  // width for axis label
-        const float labelFt = a_scale.TextPx(UI::Theme::FontSize.body);
-        const float valFt = a_scale.TextPx(UI::Theme::FontSize.body);
-        const float availW = ImGuiMCP::GetContentRegionAvail().x - rowPadH * 2.0f;
-        const float trackW = availW - labelW - valW - rowPadH * 2.0f;  // space between label and value
-
+        const float horizontalPadding = a_scale.Px(UI::Theme::Spacing.lg);
+        const float trackHeight = a_scale.Px(kTrackHeight);
+        const float needleWidth = a_scale.Px(kTrackNeedleWidth);
+        const float hitExtension = a_scale.Px(kTrackHitExtension);
+        const float valueWidth = a_scale.Px(kTrackValueWidth);
+        const float labelWidth = a_scale.Px(kTrackLabelWidth);
+        const float availableWidth = ImGuiMCP::GetContentRegionAvail().x - horizontalPadding * 2.0f;
+        const float trackWidth = availableWidth - labelWidth - valueWidth - horizontalPadding * 2.0f;
+        const float rowHeight = hitExtension * 2.0f + trackHeight + a_scale.Px(UI::Theme::Spacing.md);
         const ImGuiMCP::ImVec2 rowOrigin = ImGuiMCP::GetCursorScreenPos();
-        const float rowH = hitExt * 2.0f + trackH + a_scale.Px(8.0f);
-        const float rowCenterY = rowOrigin.y + rowH * 0.5f;
+        const float rowCenterY = rowOrigin.y + rowHeight * 0.5f;
+        const float rowEndY = rowOrigin.y + rowHeight;
 
-        // ────── All on one line: Label | Track | Value
+        ImGuiMCP::Dummy({ availableWidth, rowHeight });
+        ImGuiMCP::SetCursorScreenPos(rowOrigin);
+        SetWindowFontSize(a_scale.TextPx(UI::Theme::FontSize.body));
 
-        // Reserve full row height so ImGui advances the cursor correctly at the end
-        ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ availW, rowH });
-        ImGuiMCP::SetCursorScreenPos(rowOrigin);  // rewind; we draw manually below
-        SetWindowFontSize(labelFt);
-
-        // Label (double-click resets to baseline)
-        const float labelTextH = ImGuiMCP::CalcTextSize(axisLabel).y;
-        const ImGuiMCP::ImVec2 lblMin = { rowOrigin.x + rowPadH, rowCenterY - labelTextH * 0.5f };
-        ImGuiMCP::SetCursorScreenPos(lblMin);
-        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "%s", axisLabel);
-        const ImGuiMCP::ImVec2 lblMax = ImGuiMCP::ImVec2{ lblMin.x + ImGuiMCP::CalcTextSize(axisLabel).x, lblMin.y + labelTextH };
-        if (ImGuiMCP::IsMouseHoveringRect(lblMin, lblMax) &&
-            ImGuiMCP::IsMouseDoubleClicked(ImGuiMCP::ImGuiMouseButton_Left)) {
-            state.value = state.baseline;
+        const ImGuiMCP::ImVec2 labelSize = ImGuiMCP::CalcTextSize(a_axis.label);
+        const ImGuiMCP::ImVec2 labelMin{ rowOrigin.x + horizontalPadding, rowCenterY - labelSize.y * 0.5f };
+        const ImGuiMCP::ImVec2 labelMax{ labelMin.x + labelSize.x, labelMin.y + labelSize.y };
+        ImGuiMCP::SetCursorScreenPos(labelMin);
+        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "%s", a_axis.label);
+        if (ImGuiMCP::IsMouseHoveringRect(labelMin, labelMax) && ImGuiMCP::IsMouseDoubleClicked(ImGuiMCP::ImGuiMouseButton_Left)) {
+            a_state.value = a_state.baseline;
             changed = true;
         }
 
-        // Track (+ needle + fill)
-        const ImGuiMCP::ImVec2 trackMin = { rowOrigin.x + rowPadH + labelW + rowPadH, rowCenterY - trackH * 0.5f };
-        const ImGuiMCP::ImVec2 trackMax = ImGuiMCP::ImVec2{ trackMin.x + trackW, trackMin.y + trackH };
-
-        // Invisible button with extended hit area
-        const ImGuiMCP::ImVec2 hitMin = ImGuiMCP::ImVec2{ trackMin.x, trackMin.y - hitExt };
-        const ImGuiMCP::ImVec2 hitMax = ImGuiMCP::ImVec2{ trackMax.x, trackMax.y + hitExt };
+        const ImGuiMCP::ImVec2 trackMin{ rowOrigin.x + horizontalPadding * 2.0f + labelWidth, rowCenterY - trackHeight * 0.5f };
+        const ImGuiMCP::ImVec2 trackMax{ trackMin.x + trackWidth, trackMin.y + trackHeight };
+        const ImGuiMCP::ImVec2 hitMin{ trackMin.x, trackMin.y - hitExtension };
         ImGuiMCP::SetCursorScreenPos(hitMin);
-        ImGuiMCP::InvisibleButton("##slpp_oamTrack", ImGuiMCP::ImVec2{ trackW, trackH + hitExt * 2.0f });
-        const bool hovered = ImGuiMCP::IsItemHovered();
-        const bool active = ImGuiMCP::IsItemActive();
+        ImGuiMCP::InvisibleButton("##slpp_oamTrack", { trackWidth, trackHeight + hitExtension * 2.0f });
+        const bool trackHovered = ImGuiMCP::IsItemHovered();
+        const bool trackActive = ImGuiMCP::IsItemActive();
+        const bool trackActivated = ImGuiMCP::IsItemActivated();
 
-        // Value (input field)
-        const float inputH = ImGuiMCP::GetFrameHeight();
-        ImGuiMCP::SetCursorScreenPos({ rowOrigin.x + rowPadH + labelW + rowPadH + trackW + rowPadH, rowCenterY - inputH * 0.5f });
-        SetWindowFontSize(valFt);
-        char valBuf[16];
-        std::snprintf(valBuf, sizeof(valBuf),
-            "%d", static_cast<int>(std::round(state.value)));
-        ImGuiMCP::SetNextItemWidth(valW);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_FrameBg, UI::Theme::Color.transparent);
-        const ImGuiMCP::ImU32 valTextCol = UI::Theme::Color.textMuted;
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, valTextCol);
-        if (ImGuiMCP::InputText("##slpp_oamVal", valBuf, sizeof(valBuf),
-                ImGuiMCP::ImGuiInputTextFlags_EnterReturnsTrue | ImGuiMCP::ImGuiInputTextFlags_CharsDecimal)) {
-            float v = std::round(std::strtof(valBuf, nullptr));
-            if (std::isnan(v))
-                v = state.value;
-            if (range == kRangeR)
-                v = std::clamp(v, -kRangeR, kRangeR);
-            state.value = v;
-            changed = true;
-        }
-        if (ImGuiMCP::IsItemDeactivatedAfterEdit()) {
-            float v = std::round(std::strtof(valBuf, nullptr));
-            if (!std::isnan(v)) {
-                if (range == kRangeR)
-                    v = std::clamp(v, -kRangeR, kRangeR);
-                state.value = v;
-                changed = true;
-            }
-        }
-        ImGuiMCP::PopStyleColor(2);
-
-        // Drag (activated on first frame, captures start value)
-        if (ImGuiMCP::IsItemActivated()) {
-            state.dragStartValue = state.value;
-            _draggingAxis = -1;  // will be set by caller
-            draggingOut = true;
-        }
-        if (active) {
-            const float dx = ImGuiMCP::GetMouseDragDelta(ImGuiMCP::ImGuiMouseButton_Left).x;
-            float v = std::round(state.dragStartValue + dx * (range / kDragScale));
-            if (range == kRangeR)
-                v = std::clamp(v, -kRangeR, kRangeR);
-            state.value = v;
-            draggingOut = true;  // Notify on every frame while dragging
+        if (trackActivated)
+            a_state.dragStartValue = a_state.value;
+        if (trackActive) {
+            const float dragDelta = ImGuiMCP::GetMouseDragDelta(ImGuiMCP::ImGuiMouseButton_Left).x;
+            float value = std::round(a_state.dragStartValue + dragDelta * (a_axis.displayRange / a_scale.Px(kDragDistanceUnits)));
+            if (a_axis.coordinate == Registry::CoordinateType::R)
+                value = std::clamp(value, -kRotationDisplayRange, kRotationDisplayRange);
+            a_state.value = value;
+            a_draggingOut = true;
             changed = true;
         }
 
-        // Drag released: final notification
-        if (ImGuiMCP::IsItemDeactivated() && !active) {
-            changed = true;
-        }
-
-        // Arrow keys nudge the value by 1 while the slider is hovered.
-        if (hovered) {
+        if (trackHovered) {
             float delta = 0.0f;
             if (ImGuiMCP::IsKeyPressed(ImGuiMCP::ImGuiKey_RightArrow))
                 delta = 1.0f;
             else if (ImGuiMCP::IsKeyPressed(ImGuiMCP::ImGuiKey_LeftArrow))
                 delta = -1.0f;
             if (delta != 0.0f) {
-                float v = state.value + delta;
-                if (range == kRangeR)
-                    v = std::clamp(v, -kRangeR, kRangeR);
-                state.value = v;
+                a_state.value += delta;
+                if (a_axis.coordinate == Registry::CoordinateType::R)
+                    a_state.value = std::clamp(a_state.value, -kRotationDisplayRange, kRotationDisplayRange);
                 changed = true;
             }
         }
 
-        // ── Draw track ─────────────────────────────────────────────────────────
-        auto* dl = ImGuiMCP::GetWindowDrawList();
+        const float inputHeight = ImGuiMCP::GetFrameHeight();
+        ImGuiMCP::SetCursorScreenPos({ trackMax.x + horizontalPadding, rowCenterY - inputHeight * 0.5f });
+        int inputValue = static_cast<int>(std::round(a_state.value));
+        ImGuiMCP::SetNextItemWidth(valueWidth);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_FrameBg, UI::Theme::Color.transparent);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Text, UI::Theme::Color.textMuted);
+        const bool inputSubmitted = ImGuiMCP::InputInt("##slpp_oamValue", &inputValue, 0, 0, ImGuiMCP::ImGuiInputTextFlags_EnterReturnsTrue);
+        const bool inputDeactivated = ImGuiMCP::IsItemDeactivatedAfterEdit();
+        ImGuiMCP::PopStyleColor(2);
+        if (inputSubmitted || inputDeactivated) {
+            a_state.value = static_cast<float>(inputValue);
+            if (a_axis.coordinate == Registry::CoordinateType::R)
+                a_state.value = std::clamp(a_state.value, -kRotationDisplayRange, kRotationDisplayRange);
+            changed = true;
+        }
 
-        // Track background
-        ImGuiMCP::ImDrawListManager::AddRectFilled(dl, trackMin, trackMax, UI::Theme::Offset.track, a_scale.Px(2.0f), 0);
-        ImGuiMCP::ImDrawListManager::AddRect(dl, trackMin, trackMax, UI::Theme::Offset.trackBorder, a_scale.Px(2.0f), 0, 1.0f);
+        auto* drawList = ImGuiMCP::GetWindowDrawList();
+        const float trackRounding = a_scale.Px(UI::Theme::Geometry.roundingSmall);
+        ImGuiMCP::ImDrawListManager::AddRectFilled(drawList, trackMin, trackMax, UI::Theme::Offset.track, trackRounding, 0);
+        ImGuiMCP::ImDrawListManager::AddRect(drawList, trackMin, trackMax, UI::Theme::Color.borderSubtle,
+            trackRounding, 0, a_scale.Px(UI::Theme::Geometry.borderThin));
 
-        // Center tick
-        const float cx = trackMin.x + trackW * 0.5f;
-        ImGuiMCP::ImDrawListManager::AddLine(dl,
-            ImGuiMCP::ImVec2{ cx, trackMin.y - a_scale.Px(2.0f) }, ImGuiMCP::ImVec2{ cx, trackMax.y + a_scale.Px(2.0f) },
-            UI::Theme::Offset.centerTick, 1.0f);
+        const float centerX = trackMin.x + trackWidth * 0.5f;
+        const float centerTickExtension = a_scale.Px(kTrackCenterTickExtension);
+        ImGuiMCP::ImDrawListManager::AddLine(drawList,
+            { centerX, trackMin.y - centerTickExtension }, { centerX, trackMax.y + centerTickExtension },
+            UI::Theme::Offset.centerTick, a_scale.Px(UI::Theme::Geometry.borderThin));
 
-        // Fill grows from the center out toward the needle, in either direction.
-        const float pct = std::clamp(0.5f + (state.value / range) * 0.5f, 0.0f, 1.0f);
-        const float needleX = trackMin.x + pct * trackW;
-        if (state.value != 0.0f) {
-            const float fillL = std::min(cx, needleX);
-            const float fillR = std::max(cx, needleX);
-            ImGuiMCP::ImDrawListManager::AddRectFilled(dl,
-                ImGuiMCP::ImVec2{ fillL, trackMin.y }, ImGuiMCP::ImVec2{ fillR, trackMax.y },
+        const float trackPercent = std::clamp(0.5f + (a_state.value / a_axis.displayRange) * 0.5f, 0.0f, 1.0f);
+        const float needleX = trackMin.x + trackPercent * trackWidth;
+        if (a_state.value != 0.0f) {
+            ImGuiMCP::ImDrawListManager::AddRectFilled(drawList,
+                { std::min(centerX, needleX), trackMin.y }, { std::max(centerX, needleX), trackMax.y },
                 UI::Theme::Offset.fill, 0.0f, 0);
         }
 
-        // Needle extends slightly above and below the track so it stays visible
-        const float nTop = trackMin.y - a_scale.Px(5.0f);
-        const float nBot = trackMax.y + a_scale.Px(5.0f);
-        const ImGuiMCP::ImU32 nCol = active ? UI::Theme::Offset.needleActive : UI::Theme::Offset.needle;
-        ImGuiMCP::ImDrawListManager::AddRectFilled(dl,
-            ImGuiMCP::ImVec2{ needleX - needleW * 0.5f, nTop },
-            ImGuiMCP::ImVec2{ needleX + needleW * 0.5f, nBot },
-            nCol, a_scale.Px(1.5f), 0);
+        const float needleExtension = a_scale.Px(kTrackNeedleExtension);
+        ImGuiMCP::ImDrawListManager::AddRectFilled(drawList,
+            { needleX - needleWidth * 0.5f, trackMin.y - needleExtension },
+            { needleX + needleWidth * 0.5f, trackMax.y + needleExtension },
+            trackActive ? UI::Theme::Color.textPrimary : UI::Theme::Color.textSecondary,
+            a_scale.Px(kTrackNeedleRounding), 0);
 
-        // Separator
-        const ImGuiMCP::ImVec2 sepPos = ImGuiMCP::GetCursorScreenPos();
-        ImGuiMCP::ImDrawListManager::AddLine(dl,
-            ImGuiMCP::ImVec2{ rowOrigin.x + rowPadH, sepPos.y },
-            ImGuiMCP::ImVec2{ rowOrigin.x + rowPadH + availW, sepPos.y },
-            UI::Theme::Offset.separator, 1.0f);
+        ImGuiMCP::ImDrawListManager::AddLine(drawList,
+            { rowOrigin.x + horizontalPadding, rowEndY },
+            { rowOrigin.x + horizontalPadding + availableWidth, rowEndY },
+            UI::Theme::Color.nestedSeparator, a_scale.Px(UI::Theme::Geometry.borderThin));
+        ImGuiMCP::SetCursorScreenPos({ rowOrigin.x, rowEndY });
 
         return changed;
     }
 
-    // ── Render ────────────────────────────────────────────────────────────────
-
     void OffsetAdjustPanel::Render(SceneHUD& a_hud)
     {
+        if (_targets.empty())
+            return;
+        if (_selectedTarget)
+            RenderAdjustmentPanel(a_hud);
+        else
+            RenderTargetPicker(a_hud);
+    }
+
+    void OffsetAdjustPanel::RenderTargetPicker(SceneHUD& a_hud)
+    {
         auto& scale = a_hud.GetScale();
+        const auto* io = ImGuiMCP::GetIO();
+        const float panelOffset = scale.Px(UI::Theme::Geometry.panelTabWidth + UI::Theme::Geometry.panelTabGap);
+        const float panelWidth = scale.Px(kTargetPickerWidth);
+        ImGuiMCP::SetNextWindowPos({ io->DisplaySize.x - panelOffset, io->DisplaySize.y * 0.5f }, ImGuiMCP::ImGuiCond_Always, { 1.0f, 0.5f });
+        ImGuiMCP::SetNextWindowSize({ panelWidth, 0.0f }, ImGuiMCP::ImGuiCond_Always);
 
-        auto* io = ImGuiMCP::GetIO();
-        const float dw = io->DisplaySize.x;
-        const float dh = io->DisplaySize.y;
-
-        const float offset = scale.Px(UI::Theme::Geometry.panelTabWidth + UI::Theme::Geometry.panelTabGap);
-        const float pickerW = scale.Px(200.0f);
-        const float panelW = scale.Px(300.0f);
-
-        // ── Target picker
-        if (!_panelOpen && !_items.empty()) {
-            ImGuiMCP::SetNextWindowPos(
-                ImGuiMCP::ImVec2{ dw - offset, dh * 0.5f }, ImGuiMCP::ImGuiCond_Always, ImGuiMCP::ImVec2{ 1.0f, 0.5f });
-            ImGuiMCP::SetNextWindowSize(ImGuiMCP::ImVec2{ pickerW, 0.0f }, ImGuiMCP::ImGuiCond_Always);
-            constexpr auto pFlags =
-                ImGuiMCP::ImGuiWindowFlags_NoTitleBar | ImGuiMCP::ImGuiWindowFlags_NoResize |
-                ImGuiMCP::ImGuiWindowFlags_NoMove | ImGuiMCP::ImGuiWindowFlags_NoScrollbar |
-                ImGuiMCP::ImGuiWindowFlags_NoCollapse | ImGuiMCP::ImGuiWindowFlags_AlwaysAutoResize;
-
-            if (ImGuiMCP::Begin("##slpp_OAMPicker", nullptr, pFlags)) {
-                SetWindowFontSize(scale.TextPx(UI::Theme::FontSize.sectionHeader));
-                const float titleW = ImGuiMCP::CalcTextSize("PICK TARGET").x;
-                ImGuiMCP::SetCursorPosX((pickerW - titleW) * 0.5f);
-                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textPrimary), "PICK TARGET");
-                ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(4.0f) });
-                ImGuiMCP::Separator();
-
-                if (_pickerOpen) {
-                    SetWindowFontSize(scale.TextPx(UI::Theme::FontSize.body));
-                    for (const auto& item : _items) {
-                        ImGuiMCP::PushID(static_cast<int>(item.formId));
-                        const bool isSel = _selectedId && *_selectedId == item.formId;
-
-                        std::string lbl = item.label;
-                        if (item.isScene)
-                            lbl += " [SCENE]";
-
-                        if (isSel)
-                            ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Header, UI::Theme::Color.selectionFill);
-                        if (UI::SelectableButton(lbl.c_str(), isSel, 0, ImGuiMCP::ImVec2{ 0, scale.Px(28.0f) }))
-                            OnActorSelected(a_hud, item);
-                        if (isSel)
-                            ImGuiMCP::PopStyleColor();
-                        ImGuiMCP::PopID();
-                    }
-                }
-                ImGuiMCP::SetWindowFontScale(1.0f);
-            }
+        if (!ImGuiMCP::Begin("##slpp_OAMPicker", nullptr, kPanelWindowFlags)) {
             ImGuiMCP::End();
+            return;
         }
 
-        // ── Adjustment panel
-        if (_panelOpen && _selectedId) {
-            const uint32_t actorId = *_selectedId;
-            auto& axes = _axes[actorId];
-            if (!axes[0].hasBaseline)
-                RefreshValues(a_hud, actorId);
-
-            std::string panelTitle;
-            for (const auto& item : _items) {
-                if (item.formId == actorId) {
-                    panelTitle = item.label;
-                    if (item.isScene)
-                        panelTitle += " [SCENE]";
-                    break;
-                }
-            }
-
-            ImGuiMCP::SetNextWindowPos(
-                ImGuiMCP::ImVec2{ dw - offset, dh * 0.5f }, ImGuiMCP::ImGuiCond_Always, ImGuiMCP::ImVec2{ 1.0f, 0.5f });
-            ImGuiMCP::SetNextWindowSize(ImGuiMCP::ImVec2{ panelW, 0.0f }, ImGuiMCP::ImGuiCond_Always);
-            constexpr auto panelFlags =
-                ImGuiMCP::ImGuiWindowFlags_NoTitleBar | ImGuiMCP::ImGuiWindowFlags_NoResize |
-                ImGuiMCP::ImGuiWindowFlags_NoMove | ImGuiMCP::ImGuiWindowFlags_NoScrollbar |
-                ImGuiMCP::ImGuiWindowFlags_NoCollapse | ImGuiMCP::ImGuiWindowFlags_AlwaysAutoResize;
-
-            if (ImGuiMCP::Begin("##slpp_OAMPanel", nullptr, panelFlags)) {
-                // ────── Title
-                SetWindowFontSize(scale.TextPx(UI::Theme::FontSize.sectionHeader));
-                const float titleW = ImGuiMCP::CalcTextSize(panelTitle.c_str()).x;
-                ImGuiMCP::SetCursorPosX((panelW - titleW) * 0.5f);
-                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textPrimary), "%s", panelTitle.c_str());
-                ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(4.0f) });
-                ImGuiMCP::Separator();
-
-                // ────── Stage Only
-                ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(6.0f) });
-                // toggle row
-                SetWindowFontSize(scale.TextPx(UI::Theme::FontSize.body));
-                const float toggleRowH = scale.Px(24.0f);
-                const float rowPadH = scale.Px(12.0f);
-                const float availW = ImGuiMCP::GetContentRegionAvail().x - rowPadH * 2.0f;
-                const ImGuiMCP::ImVec2 toggleRowMin = ImGuiMCP::GetCursorScreenPos();
-                ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x + rowPadH, toggleRowMin.y });
-                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::ToVec4(UI::Theme::Color.transparent));
-                if (UI::SelectableButton("##slpp_stageOnlyRow", false, 0, ImGuiMCP::ImVec2{ availW, toggleRowH })) {
-                    OnSetAdjustStageOnly(a_hud, !_adjustStageOnly);
-                }
-                ImGuiMCP::PopStyleColor();
-                // checkbox
-                bool stageOnly = _adjustStageOnly;
-                const float cbSize = ImGuiMCP::GetFrameHeight();
-                const float cbX = toggleRowMin.x + rowPadH + availW - cbSize;
-                const float cbY = toggleRowMin.y + (toggleRowH - cbSize) * 0.5f + scale.Px(3.0f);
-                ImGuiMCP::SetCursorScreenPos({ cbX, cbY });
-                UI::PushCheckboxStyle(scale.Factor());
-                bool cbChanged = ImGuiMCP::Checkbox("##slpp_oamStageOnly", &stageOnly);
-                UI::PopCheckboxStyle();
-                if (cbChanged)
-                    OnSetAdjustStageOnly(a_hud, stageOnly);
-                // label
-                const ImGuiMCP::ImVec2 labelSize = ImGuiMCP::CalcTextSize("Adjust Stage Only");
-                const float labelY = toggleRowMin.y + (toggleRowH - labelSize.y) * 0.5f;
-                ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x + rowPadH, labelY });
-                ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "Adjust Stage Only");
-                ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x, toggleRowMin.y + toggleRowH });
-
-                ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Separator, UI::Theme::Offset.separator);
-                ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(6.0f) });
-                ImGuiMCP::Separator();
-                ImGuiMCP::PopStyleColor();
-
-                // ────── Axis Sliders
-                static constexpr const char* kLabels[4] = { "X", "Y", "Z", "R" };
-                static constexpr Registry::CoordinateType kAxisEnums[4] = {
-                    Registry::CoordinateType::X, Registry::CoordinateType::Y,
-                    Registry::CoordinateType::Z, Registry::CoordinateType::R
-                };
-
-                for (int i = 0; i < 4; ++i) {
-                    ImGuiMCP::PushID(i);
-                    const float range = (i == 3) ? kRangeR : kRangeXYZ;
-                    bool drag = false;
-
-                    if (OffsetTrack(scale, kLabels[i], axes[i], range, drag)) {
-                        OnSetOffset(a_hud, kAxisEnums[i], actorId, axes[i].value);
-                    }
-
-                    if (drag) {
-                        _draggingAxis = i;
-                        _draggingId = actorId;
-                    } else if (_draggingAxis == i && _draggingId == actorId && !ImGuiMCP::IsMouseDown(ImGuiMCP::ImGuiMouseButton_Left)) {
-                        _draggingAxis = -1;
-                    }
-                    ImGuiMCP::PopID();
-                }
-
-                // ────── Reset offsets button
-                ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(6.0f) });
-                const float btnW = panelW - scale.Px(24.0f);
-                ImGuiMCP::SetCursorPosX(scale.Px(12.0f));
-                if (UI::ActionButton("Reset Offsets", btnW))
-                    OnResetOffsets(a_hud);
-                ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(6.0f) });
-
-                ImGuiMCP::SetWindowFontScale(1.0f);
-            }
-            ImGuiMCP::End();
+        DrawPanelHeader(scale, "PICK TARGET");
+        SetWindowFontSize(scale.TextPx(UI::Theme::FontSize.body));
+        for (std::size_t targetIndex = 0; targetIndex < _targets.size(); ++targetIndex) {
+            const auto& target = _targets[targetIndex];
+            const std::string label = target.label + (target.isCenter ? " [SCENE]" : "");
+            ImGuiMCP::PushID(static_cast<int>(targetIndex));
+            if (UI::SelectableButton(label.c_str(), false, 0, { 0.0f, scale.Px(kTargetRowHeight) }))
+                OnTargetSelected(a_hud, targetIndex);
+            ImGuiMCP::PopID();
         }
+
+        ImGuiMCP::SetWindowFontScale(1.0f);
+        ImGuiMCP::End();
+    }
+
+    void OffsetAdjustPanel::RenderAdjustmentPanel(SceneHUD& a_hud)
+    {
+        auto& scale = a_hud.GetScale();
+        const auto* io = ImGuiMCP::GetIO();
+        const auto& target = _targets[*_selectedTarget];
+        const float panelOffset = scale.Px(UI::Theme::Geometry.panelTabWidth + UI::Theme::Geometry.panelTabGap);
+        const float panelWidth = scale.Px(kAdjustmentPanelWidth);
+        ImGuiMCP::SetNextWindowPos({ io->DisplaySize.x - panelOffset, io->DisplaySize.y * 0.5f }, ImGuiMCP::ImGuiCond_Always, { 1.0f, 0.5f });
+        ImGuiMCP::SetNextWindowSize({ panelWidth, 0.0f }, ImGuiMCP::ImGuiCond_Always);
+
+        if (!ImGuiMCP::Begin("##slpp_OAMPanel", nullptr, kPanelWindowFlags)) {
+            ImGuiMCP::End();
+            return;
+        }
+
+        const std::string title = target.label + (target.isCenter ? " [SCENE]" : "");
+        DrawPanelHeader(scale, title.c_str());
+        ImGuiMCP::Dummy({ 0.0f, scale.Px(UI::Theme::Spacing.sm) });
+        SetWindowFontSize(scale.TextPx(UI::Theme::FontSize.body));
+        if (UI::CheckboxRow("Adjust Stage Only", "slpp_oamStageOnly", _adjustStageOnly, scale.Factor()))
+            OnSetAdjustStageOnly(a_hud, _adjustStageOnly);
+
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Separator, UI::Theme::Color.nestedSeparator);
+        ImGuiMCP::Dummy({ 0.0f, scale.Px(UI::Theme::Spacing.sm) });
+        ImGuiMCP::Separator();
+        ImGuiMCP::PopStyleColor();
+
+        for (std::size_t axisIndex = 0; axisIndex < kAxisDefinitions.size(); ++axisIndex) {
+            ImGuiMCP::PushID(static_cast<int>(axisIndex));
+            bool dragging = false;
+            if (OffsetTrack(scale, kAxisDefinitions[axisIndex], _axes[axisIndex], dragging))
+                OnSetOffset(a_hud, kAxisDefinitions[axisIndex].coordinate, target.formId, _axes[axisIndex].value);
+            if (dragging)
+                _draggingAxis = axisIndex;
+            else if (_draggingAxis == axisIndex && !ImGuiMCP::IsMouseDown(ImGuiMCP::ImGuiMouseButton_Left))
+                _draggingAxis.reset();
+            ImGuiMCP::PopID();
+        }
+
+        ImGuiMCP::Dummy({ 0.0f, scale.Px(UI::Theme::Spacing.sm) });
+        const float horizontalPadding = scale.Px(UI::Theme::Spacing.lg);
+        const float availableWidth = ImGuiMCP::GetContentRegionAvail().x;
+        ImGuiMCP::SetCursorPosX(ImGuiMCP::GetCursorPosX() + horizontalPadding);
+        if (UI::ActionButton("Reset Offsets", availableWidth - horizontalPadding * 2.0f))
+            OnResetOffsets(a_hud);
+        ImGuiMCP::Dummy({ 0.0f, scale.Px(UI::Theme::Spacing.sm) });
+
+        ImGuiMCP::SetWindowFontScale(1.0f);
+        ImGuiMCP::End();
     }
 }

--- a/src/Thread/Interface/Elements/OffsetAdjustPanel.cpp
+++ b/src/Thread/Interface/Elements/OffsetAdjustPanel.cpp
@@ -8,18 +8,6 @@ namespace Thread::Interface
 
     namespace
     {
-        constexpr float kTargetPickerWidth = 200.0f;
-        constexpr float kAdjustmentPanelWidth = 300.0f;
-        constexpr float kTargetRowHeight = 28.0f;
-        constexpr float kTrackHitExtension = 10.0f;
-        constexpr float kTrackValueWidth = 40.0f;
-        constexpr float kTrackLabelWidth = 20.0f;
-        constexpr float kTrackHeight = 4.0f;
-        constexpr float kTrackNeedleWidth = 3.0f;
-        constexpr float kTrackNeedleExtension = 5.0f;
-        constexpr float kTrackNeedleRounding = 1.5f;
-        constexpr float kTrackCenterTickExtension = 2.0f;
-        constexpr float kDragDistanceUnits = 300.0f;
         constexpr float kDegreesPerRadian = 180.0f / std::numbers::pi_v<float>;
         constexpr auto kPanelWindowFlags =
             ImGuiMCP::ImGuiWindowFlags_NoTitleBar | ImGuiMCP::ImGuiWindowFlags_NoResize |
@@ -48,17 +36,13 @@ namespace Thread::Interface
         _hasFurnitureCenter = center && !center->IsPlayerRef();
         _adjustStageOnly = instance->GetThreadProperty<bool>("VarUI_AdjustStage");
         RefreshTargets(a_hud);
-
-        if (_targets.size() == 1)
-            OnTargetSelected(a_hud, 0);
+        for (auto& target : _targets)
+            RefreshValues(a_hud, target);
     }
 
     void OffsetAdjustPanel::Close()
     {
         _targets.clear();
-        _axes = {};
-        _selectedTarget.reset();
-        _draggingAxis.reset();
         _hasFurnitureCenter = false;
         _adjustStageOnly = false;
     }
@@ -71,14 +55,19 @@ namespace Thread::Interface
             return;
 
         if (_hasFurnitureCenter)
-            _targets.push_back({ nullptr, 0, 0, "Center", true });
+            _targets.push_back({ .label = "Center", .isCenter = true });
 
         const auto actors = instance->GetActors();
         for (std::size_t positionIndex = 0; positionIndex < actors.size(); ++positionIndex) {
             auto* actor = actors[positionIndex];
             if (!actor)
                 continue;
-            _targets.push_back({ actor, actor->GetFormID(), positionIndex, actor->GetDisplayFullName(), false });
+            _targets.push_back({
+                .actor = actor,
+                .formId = actor->GetFormID(),
+                .positionIndex = positionIndex,
+                .label = actor->GetDisplayFullName(),
+            });
         }
 
         std::ranges::sort(_targets, [](const TargetItem& a_left, const TargetItem& a_right) {
@@ -92,11 +81,8 @@ namespace Thread::Interface
         });
     }
 
-    void OffsetAdjustPanel::RefreshValues(SceneHUD& a_hud)
+    void OffsetAdjustPanel::RefreshValues(SceneHUD& a_hud, TargetItem& a_target)
     {
-        if (!_selectedTarget)
-            return;
-
         auto* instance = a_hud.GetThreadInstance();
         if (!instance)
             return;
@@ -105,19 +91,18 @@ namespace Thread::Interface
         if (!scene || !stage)
             return;
 
-        const auto& target = _targets[*_selectedTarget];
         const Registry::Coordinate* offset = nullptr;
-        if (target.isCenter) {
+        if (a_target.isCenter) {
             offset = &scene->furnitureOffset.GetOffset();
-        } else if (target.positionIndex < stage->positions.size()) {
-            offset = &stage->positions[target.positionIndex].offset.GetOffset();
+        } else if (a_target.positionIndex < stage->positions.size()) {
+            offset = &stage->positions[a_target.positionIndex].offset.GetOffset();
         }
         if (!offset)
             return;
 
         const std::array rawValues{ offset->location.x, offset->location.y, offset->location.z, offset->rotation };
         for (std::size_t axisIndex = 0; axisIndex < kAxisDefinitions.size(); ++axisIndex) {
-            auto& state = _axes[axisIndex];
+            auto& state = a_target.axes[axisIndex];
             const float value = kAxisDefinitions[axisIndex].coordinate == Registry::CoordinateType::R ?
                                     rawValues[axisIndex] * kDegreesPerRadian :
                                     rawValues[axisIndex];
@@ -125,22 +110,15 @@ namespace Thread::Interface
                 state.baseline = value;
                 state.hasBaseline = true;
             }
-            if (_draggingAxis != axisIndex)
+            if (a_target.draggingAxis != axisIndex)
                 state.value = value;
         }
     }
 
     void OffsetAdjustPanel::RefreshStageOffsets(SceneHUD& a_hud)
     {
-        RefreshValues(a_hud);
-    }
-
-    void OffsetAdjustPanel::OnTargetSelected(SceneHUD& a_hud, std::size_t a_targetIndex)
-    {
-        _selectedTarget = a_targetIndex;
-        _axes = {};
-        _draggingAxis.reset();
-        RefreshValues(a_hud);
+        for (auto& target : _targets)
+            RefreshValues(a_hud, target);
     }
 
     void OffsetAdjustPanel::OnSetOffset(SceneHUD& a_hud, Registry::CoordinateType a_axis, std::uint32_t a_targetId, float a_value)
@@ -152,12 +130,14 @@ namespace Thread::Interface
     void OffsetAdjustPanel::OnResetOffsets(SceneHUD& a_hud)
     {
         auto* instance = a_hud.GetThreadInstance();
-        if (!instance || !_selectedTarget)
+        if (!instance)
             return;
         instance->OffsetAdjustReset(_hasFurnitureCenter);
-        _axes = {};
-        _draggingAxis.reset();
-        RefreshValues(a_hud);
+        for (auto& target : _targets) {
+            target.axes = {};
+            target.draggingAxis.reset();
+            RefreshValues(a_hud, target);
+        }
     }
 
     void OffsetAdjustPanel::OnSetAdjustStageOnly(SceneHUD& a_hud, bool a_state)
@@ -167,27 +147,28 @@ namespace Thread::Interface
             instance->SetThreadProperty<bool>("VarUI_AdjustStage", a_state);
     }
 
-    bool OffsetAdjustPanel::OffsetTrack(UI::Scale& a_scale, const AxisDefinition& a_axis, AxisState& a_state, bool& a_draggingOut)
+    bool OffsetAdjustPanel::OffsetTrack(UI::Scale& a_scale, const AxisDefinition& a_axis, AxisState& a_state, float a_width, bool& a_draggingOut)
     {
         bool changed = false;
         a_draggingOut = false;
 
-        const float horizontalPadding = a_scale.Px(UI::Theme::Spacing.lg);
-        const float trackHeight = a_scale.Px(kTrackHeight);
-        const float needleWidth = a_scale.Px(kTrackNeedleWidth);
-        const float hitExtension = a_scale.Px(kTrackHitExtension);
-        const float valueWidth = a_scale.Px(kTrackValueWidth);
-        const float labelWidth = a_scale.Px(kTrackLabelWidth);
-        const float availableWidth = ImGuiMCP::GetContentRegionAvail().x - horizontalPadding * 2.0f;
+        const float nestedScale = UI::Theme::Geometry.nestedMenuScale;
+        const float horizontalPadding = a_scale.Px(UI::Theme::Spacing.lg) * nestedScale;
+        const float trackHeight = a_scale.Px(UI::Theme::Offset.trackHeight) * nestedScale;
+        const float needleWidth = a_scale.Px(UI::Theme::Offset.trackNeedleWidth) * nestedScale;
+        const float hitExtension = a_scale.Px(UI::Theme::Offset.trackHitExtension) * nestedScale;
+        const float valueWidth = a_scale.Px(UI::Theme::Offset.trackValueWidth) * nestedScale;
+        const float labelWidth = a_scale.Px(UI::Theme::Offset.trackLabelWidth) * nestedScale;
+        const float availableWidth = a_width - horizontalPadding * 2.0f;
         const float trackWidth = availableWidth - labelWidth - valueWidth - horizontalPadding * 2.0f;
-        const float rowHeight = hitExtension * 2.0f + trackHeight + a_scale.Px(UI::Theme::Spacing.md);
+        const float rowHeight = hitExtension * 2.0f + trackHeight + a_scale.Px(UI::Theme::Spacing.md) * nestedScale;
         const ImGuiMCP::ImVec2 rowOrigin = ImGuiMCP::GetCursorScreenPos();
         const float rowCenterY = rowOrigin.y + rowHeight * 0.5f;
         const float rowEndY = rowOrigin.y + rowHeight;
 
         ImGuiMCP::Dummy({ availableWidth, rowHeight });
         ImGuiMCP::SetCursorScreenPos(rowOrigin);
-        SetWindowFontSize(a_scale.TextPx(UI::Theme::FontSize.body));
+        SetWindowFontSize(a_scale.TextPx(UI::Theme::FontSize.body) * nestedScale);
 
         const ImGuiMCP::ImVec2 labelSize = ImGuiMCP::CalcTextSize(a_axis.label);
         const ImGuiMCP::ImVec2 labelMin{ rowOrigin.x + horizontalPadding, rowCenterY - labelSize.y * 0.5f };
@@ -212,7 +193,7 @@ namespace Thread::Interface
             a_state.dragStartValue = a_state.value;
         if (trackActive) {
             const float dragDelta = ImGuiMCP::GetMouseDragDelta(ImGuiMCP::ImGuiMouseButton_Left).x;
-            float value = std::round(a_state.dragStartValue + dragDelta * (a_axis.displayRange / a_scale.Px(kDragDistanceUnits)));
+            float value = std::round(a_state.dragStartValue + dragDelta * (a_axis.displayRange / (a_scale.Px(UI::Theme::Offset.dragDistance) * nestedScale)));
             if (a_axis.coordinate == Registry::CoordinateType::R)
                 value = std::clamp(value, -kRotationDisplayRange, kRotationDisplayRange);
             a_state.value = value;
@@ -251,16 +232,16 @@ namespace Thread::Interface
         }
 
         auto* drawList = ImGuiMCP::GetWindowDrawList();
-        const float trackRounding = a_scale.Px(UI::Theme::Geometry.roundingSmall);
+        const float trackRounding = a_scale.Px(UI::Theme::Geometry.roundingSmall) * nestedScale;
         ImGuiMCP::ImDrawListManager::AddRectFilled(drawList, trackMin, trackMax, UI::Theme::Offset.track, trackRounding, 0);
         ImGuiMCP::ImDrawListManager::AddRect(drawList, trackMin, trackMax, UI::Theme::Color.borderSubtle,
-            trackRounding, 0, a_scale.Px(UI::Theme::Geometry.borderThin));
+            trackRounding, 0, a_scale.Px(UI::Theme::Geometry.borderThin) * nestedScale);
 
         const float centerX = trackMin.x + trackWidth * 0.5f;
-        const float centerTickExtension = a_scale.Px(kTrackCenterTickExtension);
+        const float centerTickExtension = a_scale.Px(UI::Theme::Offset.trackCenterTickExtension) * nestedScale;
         ImGuiMCP::ImDrawListManager::AddLine(drawList,
             { centerX, trackMin.y - centerTickExtension }, { centerX, trackMax.y + centerTickExtension },
-            UI::Theme::Offset.centerTick, a_scale.Px(UI::Theme::Geometry.borderThin));
+            UI::Theme::Offset.centerTick, a_scale.Px(UI::Theme::Geometry.borderThin) * nestedScale);
 
         const float trackPercent = std::clamp(0.5f + (a_state.value / a_axis.displayRange) * 0.5f, 0.0f, 1.0f);
         const float needleX = trackMin.x + trackPercent * trackWidth;
@@ -270,17 +251,13 @@ namespace Thread::Interface
                 UI::Theme::Offset.fill, 0.0f, 0);
         }
 
-        const float needleExtension = a_scale.Px(kTrackNeedleExtension);
+        const float needleExtension = a_scale.Px(UI::Theme::Offset.trackNeedleExtension) * nestedScale;
         ImGuiMCP::ImDrawListManager::AddRectFilled(drawList,
             { needleX - needleWidth * 0.5f, trackMin.y - needleExtension },
             { needleX + needleWidth * 0.5f, trackMax.y + needleExtension },
             trackActive ? UI::Theme::Color.textPrimary : UI::Theme::Color.textSecondary,
-            a_scale.Px(kTrackNeedleRounding), 0);
+            a_scale.Px(UI::Theme::Offset.trackNeedleRounding) * nestedScale, 0);
 
-        ImGuiMCP::ImDrawListManager::AddLine(drawList,
-            { rowOrigin.x + horizontalPadding, rowEndY },
-            { rowOrigin.x + horizontalPadding + availableWidth, rowEndY },
-            UI::Theme::Color.nestedSeparator, a_scale.Px(UI::Theme::Geometry.borderThin));
         ImGuiMCP::SetCursorScreenPos({ rowOrigin.x, rowEndY });
 
         return changed;
@@ -290,49 +267,12 @@ namespace Thread::Interface
     {
         if (_targets.empty())
             return;
-        if (_selectedTarget)
-            RenderAdjustmentPanel(a_hud);
-        else
-            RenderTargetPicker(a_hud);
-    }
-
-    void OffsetAdjustPanel::RenderTargetPicker(SceneHUD& a_hud)
-    {
         auto& scale = a_hud.GetScale();
         const auto* io = ImGuiMCP::GetIO();
         const float panelOffset = scale.Px(UI::Theme::Geometry.panelTabWidth + UI::Theme::Geometry.panelTabGap);
-        const float panelWidth = scale.Px(kTargetPickerWidth);
+        const float panelWidth = scale.Px(UI::Theme::Offset.panelWidth);
         ImGuiMCP::SetNextWindowPos({ io->DisplaySize.x - panelOffset, io->DisplaySize.y * 0.5f }, ImGuiMCP::ImGuiCond_Always, { 1.0f, 0.5f });
-        ImGuiMCP::SetNextWindowSize({ panelWidth, 0.0f }, ImGuiMCP::ImGuiCond_Always);
-
-        if (!ImGuiMCP::Begin("##slpp_OAMPicker", nullptr, kPanelWindowFlags)) {
-            ImGuiMCP::End();
-            return;
-        }
-
-        DrawPanelHeader(scale, "PICK TARGET");
-        SetWindowFontSize(scale.TextPx(UI::Theme::FontSize.body));
-        for (std::size_t targetIndex = 0; targetIndex < _targets.size(); ++targetIndex) {
-            const auto& target = _targets[targetIndex];
-            const std::string label = target.label + (target.isCenter ? " [SCENE]" : "");
-            ImGuiMCP::PushID(static_cast<int>(targetIndex));
-            if (UI::SelectableButton(label.c_str(), false, 0, { 0.0f, scale.Px(kTargetRowHeight) }))
-                OnTargetSelected(a_hud, targetIndex);
-            ImGuiMCP::PopID();
-        }
-
-        ImGuiMCP::SetWindowFontScale(1.0f);
-        ImGuiMCP::End();
-    }
-
-    void OffsetAdjustPanel::RenderAdjustmentPanel(SceneHUD& a_hud)
-    {
-        auto& scale = a_hud.GetScale();
-        const auto* io = ImGuiMCP::GetIO();
-        const auto& target = _targets[*_selectedTarget];
-        const float panelOffset = scale.Px(UI::Theme::Geometry.panelTabWidth + UI::Theme::Geometry.panelTabGap);
-        const float panelWidth = scale.Px(kAdjustmentPanelWidth);
-        ImGuiMCP::SetNextWindowPos({ io->DisplaySize.x - panelOffset, io->DisplaySize.y * 0.5f }, ImGuiMCP::ImGuiCond_Always, { 1.0f, 0.5f });
+        ImGuiMCP::SetNextWindowSizeConstraints({ panelWidth, 0.0f }, { panelWidth, io->DisplaySize.y * 0.8f });
         ImGuiMCP::SetNextWindowSize({ panelWidth, 0.0f }, ImGuiMCP::ImGuiCond_Always);
 
         if (!ImGuiMCP::Begin("##slpp_OAMPanel", nullptr, kPanelWindowFlags)) {
@@ -340,29 +280,11 @@ namespace Thread::Interface
             return;
         }
 
-        const std::string title = target.label + (target.isCenter ? " [SCENE]" : "");
-        DrawPanelHeader(scale, title.c_str());
+        DrawPanelHeader(scale, "ADJUST OFFSETS");
         ImGuiMCP::Dummy({ 0.0f, scale.Px(UI::Theme::Spacing.sm) });
         SetWindowFontSize(scale.TextPx(UI::Theme::FontSize.body));
         if (UI::CheckboxRow("Adjust Stage Only", "slpp_oamStageOnly", _adjustStageOnly, scale.Factor()))
             OnSetAdjustStageOnly(a_hud, _adjustStageOnly);
-
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Separator, UI::Theme::Color.nestedSeparator);
-        ImGuiMCP::Dummy({ 0.0f, scale.Px(UI::Theme::Spacing.sm) });
-        ImGuiMCP::Separator();
-        ImGuiMCP::PopStyleColor();
-
-        for (std::size_t axisIndex = 0; axisIndex < kAxisDefinitions.size(); ++axisIndex) {
-            ImGuiMCP::PushID(static_cast<int>(axisIndex));
-            bool dragging = false;
-            if (OffsetTrack(scale, kAxisDefinitions[axisIndex], _axes[axisIndex], dragging))
-                OnSetOffset(a_hud, kAxisDefinitions[axisIndex].coordinate, target.formId, _axes[axisIndex].value);
-            if (dragging)
-                _draggingAxis = axisIndex;
-            else if (_draggingAxis == axisIndex && !ImGuiMCP::IsMouseDown(ImGuiMCP::ImGuiMouseButton_Left))
-                _draggingAxis.reset();
-            ImGuiMCP::PopID();
-        }
 
         ImGuiMCP::Dummy({ 0.0f, scale.Px(UI::Theme::Spacing.sm) });
         const float horizontalPadding = scale.Px(UI::Theme::Spacing.lg);
@@ -370,9 +292,86 @@ namespace Thread::Interface
         ImGuiMCP::SetCursorPosX(ImGuiMCP::GetCursorPosX() + horizontalPadding);
         if (UI::ActionButton("Reset Offsets", availableWidth - horizontalPadding * 2.0f))
             OnResetOffsets(a_hud);
+
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Separator, UI::Theme::Color.nestedSeparator);
         ImGuiMCP::Dummy({ 0.0f, scale.Px(UI::Theme::Spacing.sm) });
+        ImGuiMCP::Separator();
+        ImGuiMCP::Dummy({ 0.0f, scale.Px(UI::Theme::Spacing.xs) });
+
+        ImGuiMCP::PushStyleVar(ImGuiMCP::ImGuiStyleVar_ScrollbarSize, scale.Px(UI::Theme::Spacing.sm));
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarBg, UI::Theme::Color.panelBackground);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrab, UI::Theme::Color.borderSubtle);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabHovered, UI::Theme::Color.borderHovered);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_ScrollbarGrabActive, UI::Theme::Color.borderActive);
+        ImGuiMCP::SetNextWindowSizeConstraints({ 0.0f, 0.0f }, { FLT_MAX, scale.Px(UI::Theme::Offset.maxBodyHeight) });
+        ImGuiMCP::BeginChild("##slpp_oamTargets", { -FLT_MIN, 0.0f }, ImGuiMCP::ImGuiChildFlags_AutoResizeY, ImGuiMCP::ImGuiWindowFlags_None);
+
+        for (std::size_t targetIndex = 0; targetIndex < _targets.size(); ++targetIndex) {
+            if (targetIndex != 0)
+                ImGuiMCP::Separator();
+            RenderTargetCard(a_hud, _targets[targetIndex], targetIndex);
+        }
+
+        ImGuiMCP::EndChild();
+        ImGuiMCP::PopStyleColor(5);
+        ImGuiMCP::PopStyleVar();
 
         ImGuiMCP::SetWindowFontScale(1.0f);
         ImGuiMCP::End();
+    }
+
+    void OffsetAdjustPanel::RenderTargetCard(SceneHUD& a_hud, TargetItem& a_target, std::size_t a_targetIndex)
+    {
+        auto& scale = a_hud.GetScale();
+        const float nestedScale = UI::Theme::Geometry.nestedMenuScale;
+        const float contentX = ImGuiMCP::GetCursorPosX();
+        const float availableWidth = ImGuiMCP::GetContentRegionAvail().x;
+        const float cardWidth = availableWidth * nestedScale;
+        const float cardX = contentX + (availableWidth - cardWidth) * 0.5f;
+
+        ImGuiMCP::PushID(static_cast<int>(a_targetIndex));
+        ImGuiMCP::SetCursorPosX(cardX);
+        SetWindowFontSize(scale.TextPx(UI::Theme::FontSize.subsectionHeader) * nestedScale);
+        const char* badge = a_target.isCenter                               ? "SCENE" :
+                            a_target.actor && a_target.actor->IsPlayerRef() ? "PLAYER" :
+                                                                              nullptr;
+        if (UI::CollapsibleCardHeader(a_target.label.c_str(), badge, "##slpp_oamCardHeader", a_target.open,
+                cardWidth, scale.Factor() * nestedScale))
+            a_target.open = !a_target.open;
+
+        if (!a_target.open) {
+            ImGuiMCP::SetCursorPosX(contentX);
+            ImGuiMCP::PopID();
+            return;
+        }
+
+        auto* drawList = ImGuiMCP::GetWindowDrawList();
+        const ImGuiMCP::ImVec2 bodyMin = ImGuiMCP::GetCursorScreenPos();
+        ImGuiMCP::Dummy({ 0.0f, scale.Px(UI::Theme::Spacing.xs) * nestedScale });
+        ImGuiMCP::ImDrawListManager::ChannelsSplit(drawList, 2);
+        ImGuiMCP::ImDrawListManager::ChannelsSetCurrent(drawList, 1);
+
+        for (std::size_t axisIndex = 0; axisIndex < kAxisDefinitions.size(); ++axisIndex) {
+            ImGuiMCP::PushID(static_cast<int>(axisIndex));
+            ImGuiMCP::SetCursorPosX(cardX);
+            bool dragging = false;
+            if (OffsetTrack(scale, kAxisDefinitions[axisIndex], a_target.axes[axisIndex], cardWidth, dragging))
+                OnSetOffset(a_hud, kAxisDefinitions[axisIndex].coordinate, a_target.formId, a_target.axes[axisIndex].value);
+            if (dragging)
+                a_target.draggingAxis = axisIndex;
+            else if (a_target.draggingAxis == axisIndex && !ImGuiMCP::IsMouseDown(ImGuiMCP::ImGuiMouseButton_Left))
+                a_target.draggingAxis.reset();
+            ImGuiMCP::PopID();
+        }
+
+        ImGuiMCP::SetCursorPosX(cardX);
+        ImGuiMCP::Dummy({ 0.0f, scale.Px(UI::Theme::Spacing.xs) * nestedScale });
+        const ImGuiMCP::ImVec2 bodyMax{ bodyMin.x + cardWidth, ImGuiMCP::GetCursorScreenPos().y };
+        ImGuiMCP::ImDrawListManager::ChannelsSetCurrent(drawList, 0);
+        ImGuiMCP::ImDrawListManager::AddRectFilled(drawList, bodyMin, bodyMax, UI::Theme::Color.nestedSurface, 0.0f, 0);
+        ImGuiMCP::ImDrawListManager::ChannelsMerge(drawList);
+
+        ImGuiMCP::SetCursorPosX(contentX);
+        ImGuiMCP::PopID();
     }
 }

--- a/src/Thread/Interface/Elements/OffsetAdjustPanel.h
+++ b/src/Thread/Interface/Elements/OffsetAdjustPanel.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "Thread/Interface/SceneHUD.h"
 
 namespace Thread::Interface
@@ -12,52 +13,55 @@ namespace Thread::Interface
         void RefreshStageOffsets(SceneHUD& a_hud);
 
       private:
-        struct ActorItem
+        struct TargetItem
         {
             RE::Actor* actor{};
-            uint32_t formId{};
-            size_t posIdx{};
+            std::uint32_t formId{};
+            std::size_t positionIndex{};
             std::string label;
-            bool isScene{ false };
+            bool isCenter{ false };
         };
 
         struct AxisState
         {
-            float value{ 0.0f };
-            float baseline{ 0.0f };  // default value
+            float value{};
+            float baseline{};
+            float dragStartValue{};
             bool hasBaseline{ false };
-            float dragStartValue{ 0.0f };
         };
 
-        void OnActorSelected(SceneHUD& a_hud, const ActorItem& a_item);
-        void OnSetOffset(SceneHUD& a_hud, Registry::CoordinateType a_axis, std::uint32_t a_actorId, float a_value);
+        struct AxisDefinition
+        {
+            const char* label;
+            Registry::CoordinateType coordinate;
+            float displayRange;
+        };
+
+        void OnTargetSelected(SceneHUD& a_hud, std::size_t a_targetIndex);
+        void OnSetOffset(SceneHUD& a_hud, Registry::CoordinateType a_axis, std::uint32_t a_targetId, float a_value);
         void OnResetOffsets(SceneHUD& a_hud);
         void OnSetAdjustStageOnly(SceneHUD& a_hud, bool a_state);
 
-        void RefreshSlots(SceneHUD& a_hud);
-        void RefreshValues(SceneHUD& a_hud, std::uint32_t a_actorId);
+        void RefreshTargets(SceneHUD& a_hud);
+        void RefreshValues(SceneHUD& a_hud);
+        void RenderTargetPicker(SceneHUD& a_hud);
+        void RenderAdjustmentPanel(SceneHUD& a_hud);
+        bool OffsetTrack(UI::Scale& a_scale, const AxisDefinition& a_axis, AxisState& a_state, bool& a_draggingOut);
 
-        // The centered drag slider used for each axis; Returns true if value changed this frame and C++ should be notified.
-        bool OffsetTrack(UI::Scale& a_scale, const char* a_id, AxisState& a_state, float a_range, bool& a_draggingOut);
+        static constexpr float kTranslationDisplayRange = 200.0f;
+        static constexpr float kRotationDisplayRange = 180.0f;
+        static constexpr std::array kAxisDefinitions{
+            AxisDefinition{ "X", Registry::CoordinateType::X, kTranslationDisplayRange },
+            AxisDefinition{ "Y", Registry::CoordinateType::Y, kTranslationDisplayRange },
+            AxisDefinition{ "Z", Registry::CoordinateType::Z, kTranslationDisplayRange },
+            AxisDefinition{ "R", Registry::CoordinateType::R, kRotationDisplayRange },
+        };
 
-        std::vector<ActorItem> _items;
-
-        bool _hasFurniture{ false };
+        std::vector<TargetItem> _targets;
+        std::array<AxisState, kAxisDefinitions.size()> _axes{};
+        std::optional<std::size_t> _selectedTarget;
+        std::optional<std::size_t> _draggingAxis;
+        bool _hasFurnitureCenter{ false };
         bool _adjustStageOnly{ false };
-        bool _pickerOpen{ false };
-        bool _panelOpen{ false };
-
-        std::unordered_map<std::uint32_t, std::array<AxisState, 4>> _axes;
-        std::optional<std::uint32_t> _selectedId;
-
-        // Which axis is currently being dragged, and by whom;
-        // Used so a background refresh doesn't fight the player's own drag in progress.
-        int _draggingAxis{ -1 };
-        std::uint32_t _draggingId{};
-
-        static constexpr float kRangeXYZ = 200.0f;
-        static constexpr float kRangeR = 180.0f;
-        static constexpr float kDragScale = 300.0f;
-        static constexpr float kRadToDeg = 180.0f / 3.14159265358979f;
     };
 }

--- a/src/Thread/Interface/Elements/OffsetAdjustPanel.h
+++ b/src/Thread/Interface/Elements/OffsetAdjustPanel.h
@@ -13,15 +13,6 @@ namespace Thread::Interface
         void RefreshStageOffsets(SceneHUD& a_hud);
 
       private:
-        struct TargetItem
-        {
-            RE::Actor* actor{};
-            std::uint32_t formId{};
-            std::size_t positionIndex{};
-            std::string label;
-            bool isCenter{ false };
-        };
-
         struct AxisState
         {
             float value{};
@@ -37,17 +28,6 @@ namespace Thread::Interface
             float displayRange;
         };
 
-        void OnTargetSelected(SceneHUD& a_hud, std::size_t a_targetIndex);
-        void OnSetOffset(SceneHUD& a_hud, Registry::CoordinateType a_axis, std::uint32_t a_targetId, float a_value);
-        void OnResetOffsets(SceneHUD& a_hud);
-        void OnSetAdjustStageOnly(SceneHUD& a_hud, bool a_state);
-
-        void RefreshTargets(SceneHUD& a_hud);
-        void RefreshValues(SceneHUD& a_hud);
-        void RenderTargetPicker(SceneHUD& a_hud);
-        void RenderAdjustmentPanel(SceneHUD& a_hud);
-        bool OffsetTrack(UI::Scale& a_scale, const AxisDefinition& a_axis, AxisState& a_state, bool& a_draggingOut);
-
         static constexpr float kTranslationDisplayRange = 200.0f;
         static constexpr float kRotationDisplayRange = 180.0f;
         static constexpr std::array kAxisDefinitions{
@@ -57,10 +37,28 @@ namespace Thread::Interface
             AxisDefinition{ "R", Registry::CoordinateType::R, kRotationDisplayRange },
         };
 
+        struct TargetItem
+        {
+            RE::Actor* actor{};
+            std::uint32_t formId{};
+            std::size_t positionIndex{};
+            std::string label;
+            std::array<AxisState, kAxisDefinitions.size()> axes{};
+            std::optional<std::size_t> draggingAxis;
+            bool isCenter{ false };
+            bool open{ true };
+        };
+
+        void OnSetOffset(SceneHUD& a_hud, Registry::CoordinateType a_axis, std::uint32_t a_targetId, float a_value);
+        void OnResetOffsets(SceneHUD& a_hud);
+        void OnSetAdjustStageOnly(SceneHUD& a_hud, bool a_state);
+
+        void RefreshTargets(SceneHUD& a_hud);
+        void RefreshValues(SceneHUD& a_hud, TargetItem& a_target);
+        void RenderTargetCard(SceneHUD& a_hud, TargetItem& a_target, std::size_t a_targetIndex);
+        bool OffsetTrack(UI::Scale& a_scale, const AxisDefinition& a_axis, AxisState& a_state, float a_width, bool& a_draggingOut);
+
         std::vector<TargetItem> _targets;
-        std::array<AxisState, kAxisDefinitions.size()> _axes{};
-        std::optional<std::size_t> _selectedTarget;
-        std::optional<std::size_t> _draggingAxis;
         bool _hasFurnitureCenter{ false };
         bool _adjustStageOnly{ false };
     };

--- a/src/Thread/Interface/Elements/ThreadConfigPanel.cpp
+++ b/src/Thread/Interface/Elements/ThreadConfigPanel.cpp
@@ -394,7 +394,7 @@ namespace Thread::Interface
         const float panelW = scale.Px(280.0f);
         const float offset = scale.Px(UI::Theme::Geometry.panelTabWidth + UI::Theme::Geometry.panelTabGap);
         const float rowMinH = scale.Px(28.0f);
-        const float rowPadH = scale.Px(12.0f);
+        const float rowPadH = scale.Px(UI::Theme::Spacing.lg);
         const float maxBodyH = scale.Px(340.0f);  // before scrolling
 
         ImGuiMCP::SetNextWindowPos(
@@ -417,34 +417,9 @@ namespace Thread::Interface
 
         // ── Auto Advance toggle
         SetWindowFontSize(scale.TextPx(UI::Theme::FontSize.body));
-        const float toggleRowH = scale.Px(24.0f);
-        const float availW = ImGuiMCP::GetContentRegionAvail().x - rowPadH * 2.0f;
-        const ImGuiMCP::ImVec2 toggleRowMin = ImGuiMCP::GetCursorScreenPos();
-        ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x + rowPadH, toggleRowMin.y });
-
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::ToVec4(UI::Theme::Color.transparent));
-        if (UI::SelectableButton("##slpp_autoAdvanceRow", false, 0, ImGuiMCP::ImVec2{ availW, toggleRowH })) {
-            bool autoPlay = inst->GetThreadProperty<bool>("AutoAdvance");
-            OnAutoPlaySet(a_hud, !autoPlay);
-        }
-        ImGuiMCP::PopStyleColor();
-
         bool autoPlay = inst->GetThreadProperty<bool>("AutoAdvance");
-        const float cbSize = ImGuiMCP::GetFrameHeight();
-        const float cbX = toggleRowMin.x + rowPadH + availW - cbSize;
-        const float cbY = toggleRowMin.y + (toggleRowH - cbSize) * 0.5f + scale.Px(3.0f);
-        ImGuiMCP::SetCursorScreenPos({ cbX, cbY });
-        UI::PushCheckboxStyle(scale.Factor());
-        bool cbChanged = ImGuiMCP::Checkbox("##slpp_tcmAutoAdvance", &autoPlay);
-        UI::PopCheckboxStyle();
-        if (cbChanged)
+        if (UI::CheckboxRow("Auto Advance", "slpp_tcmAutoAdvance", autoPlay, scale.Factor()))
             OnAutoPlaySet(a_hud, autoPlay);
-
-        const ImGuiMCP::ImVec2 labelSize = ImGuiMCP::CalcTextSize("Auto Advance");
-        const float labelY = toggleRowMin.y + (toggleRowH - labelSize.y) * 0.5f;
-        ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x + rowPadH, labelY });
-        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "Auto Advance");
-        ImGuiMCP::SetCursorScreenPos({ toggleRowMin.x, toggleRowMin.y + toggleRowH });
 
         ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(UI::Theme::Spacing.md) });
 

--- a/src/Thread/Interface/Elements/ThreadConfigPanel.cpp
+++ b/src/Thread/Interface/Elements/ThreadConfigPanel.cpp
@@ -113,8 +113,6 @@ namespace Thread::Interface
         const float cardX = contentX + (availableW - cardW) * 0.5f;
         const float rowPadV = scale.Px(6.0f) * nestedScale;
         const float rowPadH = scale.Px(12.0f) * nestedScale;
-        const float hdrPadV = scale.Px(5.0f) * nestedScale;
-        const float hdrPadH = scale.Px(10.0f) * nestedScale;
         const float fieldGap = scale.Px(UI::Theme::Spacing.sm) * nestedScale;
         const float captionSize = scale.TextPx(UI::Theme::FontSize.caption) * nestedScale;
         const float subsectionHeaderSize = scale.TextPx(UI::Theme::FontSize.subsectionHeader) * nestedScale;
@@ -137,62 +135,12 @@ namespace Thread::Interface
 
         ImGuiMCP::PushID(static_cast<int>(actor->GetFormID()));
 
-        // ── Card header ─────────────────────────────────────────────────────
-        // An invisible-label Selectable provides the real user interaction here.
-        // The header's actual content (toggle, name, badge) is drawn on top of it afterward.
         ImGuiMCP::SetCursorPosX(cardX);
-        const ImGuiMCP::ImVec2 hdrMin = ImGuiMCP::GetCursorScreenPos();
-        const float hdrH = subsectionHeaderSize + hdrPadV * 2.0f;
-
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Header, UI::Theme::Color.nestedHeader);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, UI::Theme::Color.nestedHeaderHovered);
-        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderActive, UI::Theme::Color.nestedControlActive);
-        if (ImGuiMCP::Selectable("##slpp_tcmCardHdr", false, 0, ImGuiMCP::ImVec2{ cardW, hdrH }))
-            state.cardOpen = !state.cardOpen;
-        ImGuiMCP::PopStyleColor(3);
-        const bool hdrHov = ImGuiMCP::IsItemHovered();
-
-        // Selectable only paints interaction states, so supply the idle header surface.
-        auto* dl = ImGuiMCP::GetWindowDrawList();
-        if (!hdrHov) {
-            const ImGuiMCP::ImVec2 hdrMax{ hdrMin.x + cardW, hdrMin.y + hdrH };
-            ImGuiMCP::ImDrawListManager::AddRectFilled(dl, hdrMin, hdrMax, UI::Theme::Color.nestedHeader, 0.0f, 0);
-        }
-
-        ImGuiMCP::SetCursorScreenPos(hdrMin);
         SetWindowFontSize(subsectionHeaderSize);
-
-        // Left accent bar to distinguish actor cards from section headers
-        const float accentBarW = scale.Px(2.0f) * nestedScale;
-        ImGuiMCP::ImDrawListManager::AddRectFilled(dl,
-            ImGuiMCP::ImVec2{ hdrMin.x, hdrMin.y },
-            ImGuiMCP::ImVec2{ hdrMin.x + accentBarW, hdrMin.y + hdrH },
-            hdrHov ? UI::Theme::Color.accent : UI::Theme::Color.borderSubtle, 0.0f, 0);
-
-        // Name at left with padding
-        ImGuiMCP::SetCursorScreenPos(ImGuiMCP::ImVec2{ hdrMin.x + hdrPadH, hdrMin.y + hdrPadV });
-        ImGuiMCP::TextColored(UI::Theme::ToVec4(hdrHov ? UI::Theme::Color.textPrimary : UI::Theme::Color.textSecondary),
-            "%s", actor->GetDisplayFullName());
-
-        // Right side: PLAYER badge then toggle icon, both flush-right
-        SKSEMenuFramework::PushFont(UI::Theme::Icon::solidFont);
-        const char* toggleIcon = state.cardOpen ? UI::Theme::Icon::minus : UI::Theme::Icon::plus;
-        const ImGuiMCP::ImVec2 toggleIconSize = ImGuiMCP::CalcTextSize(toggleIcon);
-        FontAwesome::Pop();
-
-        const float toggleIconX = hdrMin.x + cardW - hdrPadH - toggleIconSize.x;
-        if (actor->IsPlayerRef()) {
-            const ImGuiMCP::ImVec2 badgeSize = ImGuiMCP::CalcTextSize("PLAYER");
-            const float badgeX = toggleIconX - fieldGap - badgeSize.x;
-            ImGuiMCP::SetCursorScreenPos(ImGuiMCP::ImVec2{ badgeX, hdrMin.y + hdrPadV });
-            ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.accent), "PLAYER");
-        }
-        SKSEMenuFramework::PushFont(UI::Theme::Icon::solidFont);
-        ImGuiMCP::SetCursorScreenPos(ImGuiMCP::ImVec2{ toggleIconX, hdrMin.y + hdrPadV });
-        ImGuiMCP::TextColored(UI::Theme::ToVec4(UI::Theme::Color.textSecondary), "%s", toggleIcon);
-        FontAwesome::Pop();
-
-        ImGuiMCP::SetCursorScreenPos(ImGuiMCP::ImVec2{ hdrMin.x, hdrMin.y + hdrH });
+        if (UI::CollapsibleCardHeader(actor->GetDisplayFullName(), actor->IsPlayerRef() ? "PLAYER" : nullptr,
+                "##slpp_tcmCardHdr", state.cardOpen, cardW, scale.Factor() * nestedScale))
+            state.cardOpen = !state.cardOpen;
+        auto* dl = ImGuiMCP::GetWindowDrawList();
 
         // ── Card body (collapsible) ─────────────────────────────────────────
         if (!state.cardOpen) {
@@ -202,7 +150,7 @@ namespace Thread::Interface
             return;
         }
         auto* inst = a_hud.GetThreadInstance();
-        const ImGuiMCP::ImVec2 bodyMin{ hdrMin.x, hdrMin.y + hdrH };
+        const ImGuiMCP::ImVec2 bodyMin = ImGuiMCP::GetCursorScreenPos();
         ImGuiMCP::SetCursorScreenPos(bodyMin);
         ImGuiMCP::Dummy(ImGuiMCP::ImVec2{ 0.0f, scale.Px(UI::Theme::Spacing.xs) * nestedScale });
         ImGuiMCP::ImDrawListManager::ChannelsSplit(dl, 2);
@@ -370,7 +318,7 @@ namespace Thread::Interface
         ImGuiMCP::SetCursorPosY(ImGuiMCP::GetCursorPosY() + rowPadV);
         ImGuiMCP::PopStyleColor(6);
 
-        const ImGuiMCP::ImVec2 bodyMax{ hdrMin.x + cardW, ImGuiMCP::GetCursorScreenPos().y };
+        const ImGuiMCP::ImVec2 bodyMax{ cardX + cardW, ImGuiMCP::GetCursorScreenPos().y };
         ImGuiMCP::ImDrawListManager::ChannelsSetCurrent(dl, 0);
         ImGuiMCP::ImDrawListManager::AddRectFilled(
             dl, bodyMin, bodyMax, UI::Theme::Color.nestedSurface, 0.0f, 0);

--- a/src/Thread/Interface/UI/Theme.h
+++ b/src/Thread/Interface/UI/Theme.h
@@ -83,6 +83,7 @@ namespace Thread::Interface::UI::Theme
         float roundingEnjBar = 3.0f;
         float borderThin = 1.0f;
         float checkboxPaddingY = 0.5f;
+        float checkboxRowHeight = 24.0f;
         float panelTabWidth = 78.0f;
         float panelTabGap = 8.0f;
         float nestedMenuScale = 0.90f;
@@ -122,12 +123,8 @@ namespace Thread::Interface::UI::Theme
     struct OffsetValues final
     {
         ImGuiMCP::ImU32 fill = IM_COL32(160, 160, 160, 56);
-        ImGuiMCP::ImU32 needle = IM_COL32(176, 168, 152, 255);
-        ImGuiMCP::ImU32 needleActive = IM_COL32(221, 216, 208, 255);
         ImGuiMCP::ImU32 track = IM_COL32(255, 255, 255, 10);
-        ImGuiMCP::ImU32 trackBorder = IM_COL32(58, 58, 58, 128);
         ImGuiMCP::ImU32 centerTick = IM_COL32(255, 255, 255, 26);
-        ImGuiMCP::ImU32 separator = IM_COL32(38, 38, 38, 115);
     };
 
     struct AnimationValues final
@@ -221,6 +218,38 @@ namespace Thread::Interface::UI
     inline void PopCheckboxStyle()
     {
         ImGuiMCP::PopStyleVar();
+    }
+
+    inline bool CheckboxRow(const char* a_label, const char* a_id, bool& a_value, float a_scale)
+    {
+        ImGuiMCP::PushID(a_id);
+        const float horizontalPadding = Theme::Spacing.lg * a_scale;
+        const float rowHeight = Theme::Geometry.checkboxRowHeight * a_scale;
+        const float availableWidth = ImGuiMCP::GetContentRegionAvail().x - horizontalPadding * 2.0f;
+        const ImGuiMCP::ImVec2 rowOrigin = ImGuiMCP::GetCursorScreenPos();
+        ImGuiMCP::SetCursorScreenPos({ rowOrigin.x + horizontalPadding, rowOrigin.y });
+
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, Theme::Color.transparent);
+        const bool rowClicked = SelectableButton("##row", false, ImGuiMCP::ImGuiSelectableFlags_AllowOverlap, { availableWidth, rowHeight });
+        ImGuiMCP::PopStyleColor();
+
+        PushCheckboxStyle(a_scale);
+        const float checkboxSize = ImGuiMCP::GetFrameHeight();
+        ImGuiMCP::SetCursorScreenPos({ rowOrigin.x + horizontalPadding + availableWidth - checkboxSize,
+            rowOrigin.y + (rowHeight - checkboxSize) * 0.5f });
+        const bool checkboxChanged = ImGuiMCP::Checkbox("##checkbox", &a_value);
+        PopCheckboxStyle();
+
+        const ImGuiMCP::ImVec2 labelSize = ImGuiMCP::CalcTextSize(a_label);
+        ImGuiMCP::SetCursorScreenPos({ rowOrigin.x + horizontalPadding, rowOrigin.y + (rowHeight - labelSize.y) * 0.5f });
+        ImGuiMCP::TextColored(Theme::ToVec4(Theme::Color.textSecondary), "%s", a_label);
+
+        const bool rowChanged = rowClicked && !checkboxChanged;
+        if (rowChanged)
+            a_value = !a_value;
+        ImGuiMCP::SetCursorScreenPos({ rowOrigin.x, rowOrigin.y + rowHeight });
+        ImGuiMCP::PopID();
+        return rowChanged || checkboxChanged;
     }
 
     inline bool CollapsibleSectionHeader(const char* a_label, const char* a_id, bool a_open, ImGuiMCP::ImVec2 a_size)

--- a/src/Thread/Interface/UI/Theme.h
+++ b/src/Thread/Interface/UI/Theme.h
@@ -87,6 +87,9 @@ namespace Thread::Interface::UI::Theme
         float panelTabWidth = 78.0f;
         float panelTabGap = 8.0f;
         float nestedMenuScale = 0.90f;
+        float nestedHeaderPaddingX = 10.0f;
+        float nestedHeaderPaddingY = 5.0f;
+        float nestedHeaderAccentWidth = 2.0f;
     };
 
     struct EnjoymentValues final
@@ -125,6 +128,17 @@ namespace Thread::Interface::UI::Theme
         ImGuiMCP::ImU32 fill = IM_COL32(160, 160, 160, 56);
         ImGuiMCP::ImU32 track = IM_COL32(255, 255, 255, 10);
         ImGuiMCP::ImU32 centerTick = IM_COL32(255, 255, 255, 26);
+        float panelWidth = 300.0f;
+        float maxBodyHeight = 420.0f;
+        float trackHitExtension = 8.0f;
+        float trackValueWidth = 40.0f;
+        float trackLabelWidth = 20.0f;
+        float trackHeight = 4.0f;
+        float trackNeedleWidth = 3.0f;
+        float trackNeedleExtension = 5.0f;
+        float trackNeedleRounding = 1.5f;
+        float trackCenterTickExtension = 2.0f;
+        float dragDistance = 300.0f;
     };
 
     struct AnimationValues final
@@ -275,6 +289,55 @@ namespace Thread::Interface::UI
         FontAwesome::Pop();
 
         ImGuiMCP::SetCursorPos(cursorAfter);
+        return clicked;
+    }
+
+    inline bool CollapsibleCardHeader(const char* a_label, const char* a_badge, const char* a_id, bool a_open, float a_width, float a_scale)
+    {
+        const ImGuiMCP::ImVec2 headerMin = ImGuiMCP::GetCursorScreenPos();
+        const float paddingX = Theme::Geometry.nestedHeaderPaddingX * a_scale;
+        const float paddingY = Theme::Geometry.nestedHeaderPaddingY * a_scale;
+        const float headerHeight = ImGuiMCP::CalcTextSize(a_label).y + paddingY * 2.0f;
+
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_Header, Theme::Color.nestedHeader);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderHovered, Theme::Color.nestedHeaderHovered);
+        ImGuiMCP::PushStyleColor(ImGuiMCP::ImGuiCol_HeaderActive, Theme::Color.nestedControlActive);
+        const bool clicked = ImGuiMCP::Selectable(a_id, false, 0, { a_width, headerHeight });
+        ImGuiMCP::PopStyleColor(3);
+
+        const bool hovered = ImGuiMCP::IsItemHovered();
+        auto* drawList = ImGuiMCP::GetWindowDrawList();
+        if (!hovered)
+            ImGuiMCP::ImDrawListManager::AddRectFilled(drawList, headerMin, { headerMin.x + a_width, headerMin.y + headerHeight }, Theme::Color.nestedHeader, 0.0f, 0);
+
+        ImGuiMCP::ImDrawListManager::AddRectFilled(drawList, headerMin,
+            { headerMin.x + Theme::Geometry.nestedHeaderAccentWidth * a_scale, headerMin.y + headerHeight },
+            hovered ? Theme::Color.accent : Theme::Color.borderSubtle, 0.0f, 0);
+
+        const ImGuiMCP::ImVec4 textColor = Theme::ToVec4(hovered ? Theme::Color.textPrimary : Theme::Color.textSecondary);
+        const ImGuiMCP::ImVec2 labelSize = ImGuiMCP::CalcTextSize(a_label);
+        ImGuiMCP::SetCursorScreenPos({ headerMin.x + paddingX, headerMin.y + (headerHeight - labelSize.y) * 0.5f });
+        ImGuiMCP::TextColored(textColor, "%s", a_label);
+
+        SKSEMenuFramework::PushFont(Theme::Icon::solidFont);
+        const char* toggleIcon = a_open ? Theme::Icon::minus : Theme::Icon::plus;
+        const ImGuiMCP::ImVec2 toggleSize = ImGuiMCP::CalcTextSize(toggleIcon);
+        FontAwesome::Pop();
+        const float toggleX = headerMin.x + a_width - paddingX - toggleSize.x;
+
+        if (a_badge && *a_badge) {
+            const ImGuiMCP::ImVec2 badgeSize = ImGuiMCP::CalcTextSize(a_badge);
+            ImGuiMCP::SetCursorScreenPos({ toggleX - Theme::Spacing.sm * a_scale - badgeSize.x,
+                headerMin.y + (headerHeight - badgeSize.y) * 0.5f });
+            ImGuiMCP::TextColored(Theme::ToVec4(Theme::Color.accent), "%s", a_badge);
+        }
+
+        SKSEMenuFramework::PushFont(Theme::Icon::solidFont);
+        ImGuiMCP::SetCursorScreenPos({ toggleX, headerMin.y + (headerHeight - toggleSize.y) * 0.5f });
+        ImGuiMCP::TextColored(Theme::ToVec4(Theme::Color.textSecondary), "%s", toggleIcon);
+        FontAwesome::Pop();
+
+        ImGuiMCP::SetCursorScreenPos({ headerMin.x, headerMin.y + headerHeight });
         return clicked;
     }
 


### PR DESCRIPTION
Offset menu was a bit tedious for users to use. Now all the controls are on the page at once, similar to the thread UI. 

This also exposes more of it's layout to Theme.h, and centralize UI elements that are used elsewhere. Lots of other cleanup applied too, like var names

Makes the Theme panel movable too. 